### PR TITLE
net: npcm7xx: EMAC driver should not directly use seq_read.

### DIFF
--- a/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
+++ b/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
@@ -1959,7 +1959,7 @@ static int npcm7xx_ether_proc_open(struct inode *inode, struct file *file)
 
 static const struct file_operations npcm7xx_ether_proc_fops = {
 	.open           = npcm7xx_ether_proc_open,
-	.read           = seq_read,
+	.read           = npcm7xx_proc_read,
 	.llseek         = seq_lseek,
 	.release        = single_release,
 };
@@ -1987,7 +1987,7 @@ static int npcm7xx_ether_proc_reset(struct inode *inode, struct file *file)
 
 static const struct file_operations npcm7xx_ether_proc_fops_reset = {
 	.open           = npcm7xx_ether_proc_reset,
-	.read           = seq_read,
+	.read           = npcm7xx_proc_read,
 	.llseek         = seq_lseek,
 	.release        = single_release,
 };


### PR DESCRIPTION
Procfs read should be npcm7xx_proc_read function so that the read
operation correctly allocates dump memory.

Change-Id: I2bd72fbc5c1668c062c6eb5b95057c7f050b6009
Signed-off-by: Kun Yi <kunyi@google.com>