### PR TITLE
media: platform: npcm750: update vcd and ece driver

### DIFF
--- a/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
@@ -294,6 +294,7 @@
 			compatible = "nuvoton,npcm750-vcd";
 			reg = <0xf0810000 0x10000>;
 			phy-memory = <0x3e200000 0x600000>;
+			de-mode = /bits/ 8 <1>;
 			interrupts = <0 22 4>;
 			status = "disabled";
 		};


### PR DESCRIPTION
1. vcd/ece: move device initialization to probe function
2. vcd: introduce wait queue
3. vcd: add a new ioctl command for DE/HSYNC switch
4. vcd: configure default mode in dts.
5. vcd: remove unused struct.
6. vcd: enable interrupt before captrue and disable after captured.