### PR TITLE
Push GSJ device tree and EDAC driver to kernel 4.19

### DIFF
--- a/Documentation/devicetree/bindings/edac/npcm7xx-sdram-edac.txt
+++ b/Documentation/devicetree/bindings/edac/npcm7xx-sdram-edac.txt
@@ -1,0 +1,17 @@
+Nuvoton NPCM7xx SoC EDAC device driver
+
+The Nuvoton NPCM7xx SoC supports DDR4 memory with/without ECC and the driver
+uses the EDAC framework to implement the ECC detection and corrtection.
+
+Required properties:
+- compatible:	should be "nuvoton,npcm7xx-sdram-edac"
+- reg:		Memory controller register set should be <0xf0824000 0x1000>
+- interrupts:	should be MC interrupt #25
+
+Example:
+
+	mc: memory-controller@f0824000 {
+		compatible = "nuvoton,npcm7xx-sdram-edac";
+		reg = <0xf0824000 0x1000>;
+		interrupts = <0 25 4>;
+	};

--- a/arch/arm/boot/dts/nuvoton-npcm730-gsj-gpio.dtsi
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gsj-gpio.dtsi
@@ -1,0 +1,2591 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2018 Nuvoton Technology tomer.maimon@nuvoton.com
+
+/ {
+	pinctrl: pinctrl@f0800000 {
+		gpio0o_pins: gpio0o-pins {
+			pins = "GPIO0/IOX1DI";
+			bias-disable;
+			output-high;
+		};
+		gpio0ol_pins: gpio0ol-pins {
+			pins = "GPIO0/IOX1DI";
+			bias-disable;
+			output-low;
+		};
+		gpio0od_pins: gpio0od-pins {
+			pins = "GPIO0/IOX1DI";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio0pp_pins: gpio0pp-pins {
+			pins = "GPIO0/IOX1DI";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio1_pins: gpio1-pins {
+			pins = "GPIO1/IOX1LD";
+			bias-disable;
+			input-enable;
+		};
+		gpio1o_pins: gpio1o-pins {
+			pins = "GPIO1/IOX1LD";
+			bias-disable;
+			output-high;
+		};
+		gpio1ol_pins: gpio1ol-pins {
+			pins = "GPIO1/IOX1LD";
+			bias-disable;
+			output-low;
+		};
+		gpio1od_pins: gpio1od-pins {
+			pins = "GPIO1/IOX1LD";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio1pp_pins: gpio1pp-pins {
+			pins = "GPIO1/IOX1LD";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio2_pins: gpio2-pins {
+			pins = "GPIO2/IOX1CK";
+			bias-disable;
+			input-enable;
+		};
+		gpio2o_pins: gpio2o-pins {
+			pins = "GPIO2/IOX1CK";
+			bias-disable;
+			output-high;
+		};
+		gpio2ol_pins: gpio2ol-pins {
+			pins = "GPIO2/IOX1CK";
+			bias-disable;
+			output-low;
+		};
+		gpio2od_pins: gpio2od-pins {
+			pins = "GPIO2/IOX1CK";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio2pp_pins: gpio2pp-pins {
+			pins = "GPIO2/IOX1CK";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio3_pins: gpio3-pins {
+			pins = "GPIO3/IOX1D0";
+			bias-disable;
+			input-enable;
+		};
+		gpio3o_pins: gpio3o-pins {
+			pins = "GPIO3/IOX1D0";
+			bias-disable;
+			output-high;
+		};
+		gpio3ol_pins: gpio3ol-pins {
+			pins = "GPIO3/IOX1D0";
+			bias-disable;
+			output-low;
+		};
+		gpio3od_pins: gpio3od-pins {
+			pins = "GPIO3/IOX1D0";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio3pp_pins: gpio3pp-pins {
+			pins = "GPIO3/IOX1D0";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio4_pins: gpio4-pins {
+			pins = "GPIO4/IOX2DI/SMB1DSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio4ol_pins: gpio4ol-pins {
+			pins = "GPIO4/IOX2DI/SMB1DSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio4od_pins: gpio4od-pins {
+			pins = "GPIO4/IOX2DI/SMB1DSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio4pp_pins: gpio4pp-pins {
+			pins = "GPIO4/IOX2DI/SMB1DSDA";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio5_pins: gpio5-pins {
+			pins = "GPIO5/IOX2LD/SMB1DSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio5ol_pins: gpio5ol-pins {
+			pins = "GPIO5/IOX2LD/SMB1DSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio5od_pins: gpio5od-pins {
+			pins = "GPIO5/IOX2LD/SMB1DSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio5pp_pins: gpio5pp-pins {
+			pins = "GPIO5/IOX2LD/SMB1DSCL";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio6_pins: gpio6-pins {
+			pins = "GPIO6/IOX2CK/SMB2DSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio6o_pins: gpio6o-pins {
+			pins = "GPIO6/IOX2CK/SMB2DSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio6ol_pins: gpio6ol-pins {
+			pins = "GPIO6/IOX2CK/SMB2DSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio6od_pins: gpio6od-pins {
+			pins = "GPIO6/IOX2CK/SMB2DSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio6pp_pins: gpio6pp-pins {
+			pins = "GPIO6/IOX2CK/SMB2DSDA";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio7_pins: gpio7-pins {
+			pins = "GPIO7/IOX2D0/SMB2DSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio7o_pins: gpio7o-pins {
+			pins = "GPIO7/IOX2D0/SMB2DSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio7ol_pins: gpio7ol-pins {
+			pins = "GPIO7/IOX2D0/SMB2DSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio7od_pins: gpio7od-pins {
+			pins = "GPIO7/IOX2D0/SMB2DSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio7pp_pins: gpio7pp-pins {
+			pins = "GPIO7/IOX2D0/SMB2DSCL";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio8_pins: gpio8-pins {
+			pins = "GPIO8/LKGPO1";
+			bias-disable;
+			input-enable;
+		};
+		gpio8ol_pins: gpio8ol-pins {
+			pins = "GPIO8/LKGPO1";
+			bias-disable;
+			output-low;
+		};
+		gpio9_pins: gpio9-pins {
+			pins = "GPIO9/LKGPO2";
+			bias-disable;
+			input-enable;
+		};
+		gpio9o_pins: gpio9o-pins {
+			pins = "GPIO9/LKGPO2";
+			bias-disable;
+			output-high;
+		};
+		gpio9ol_pins: gpio9ol-pins {
+			pins = "GPIO9/LKGPO2";
+			bias-disable;
+			output-low;
+		};
+		gpio10_pins: gpio10-pins {
+			pins = "GPIO10/IOXHLD";
+			bias-disable;
+			input-enable;
+		};
+		gpio10ol_pins: gpio10ol-pins {
+			pins = "GPIO10/IOXHLD";
+			bias-disable;
+			output-low;
+		};
+		gpio10od_pins: gpio10od-pins {
+			pins = "GPIO10/IOXHLD";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio10pp_pins: gpio10pp-pins {
+			pins = "GPIO10/IOXHLD";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio11_pins: gpio11-pins {
+			pins = "GPIO11/IOXHCK";
+			bias-disable;
+			input-enable;
+		};
+		gpio11o_pins: gpio11o-pins {
+			pins = "GPIO11/IOXHCK";
+			bias-disable;
+			output-high;
+		};
+		gpio11ol_pins: gpio11ol-pins {
+			pins = "GPIO11/IOXHCK";
+			bias-disable;
+			output-low;
+		};
+		gpio11od_pins: gpio11od-pins {
+			pins = "GPIO11/IOXHCK";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio11pp_pins: gpio11pp-pins {
+			pins = "GPIO11/IOXHCK";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio12_pins: gpio12-pins {
+			pins = "GPIO12/GSPICK/SMB5BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio12o_pins: gpio12o-pins {
+			pins = "GPIO12/GSPICK/SMB5BSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio12ol_pins: gpio12ol-pins {
+			pins = "GPIO12/GSPICK/SMB5BSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio13_pins: gpio13-pins {
+			pins = "GPIO13/GSPIDO/SMB5BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio13ol_pins: gpio13ol-pins {
+			pins = "GPIO13/GSPIDO/SMB5BSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio14_pins: gpio14-pins {
+			pins = "GPIO14/GSPIDI/SMB5CSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio14ol_pins: gpio14ol-pins {
+			pins = "GPIO14/GSPIDI/SMB5CSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio15_pins: gpio15-pins {
+			pins = "GPIO15/GSPICS/SMB5CSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio15o_pins: gpio15o-pins {
+			pins = "GPIO15/GSPICS/SMB5CSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio15od_pins: gpio15od-pins {
+			pins = "GPIO15/GSPICS/SMB5CSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio16_pins: gpio16-pins {
+			pins = "GPIO16/LKGPO0";
+			bias-disable;
+			input-enable;
+		};
+		gpio16o_pins: gpio16o-pins {
+			pins = "GPIO16/LKGPO0";
+			bias-disable;
+			output-high;
+		};
+		gpio16ol_pins: gpio16ol-pins {
+			pins = "GPIO16/LKGPO0";
+			bias-disable;
+			output-low;
+		};
+		gpio17_pins: gpio17-pins {
+			pins = "GPIO17/PSPI2DI/SMB4DEN";
+			bias-disable;
+			input-enable;
+		};
+		gpio17o_pins: gpio17o-pins {
+			pins = "GPIO17/PSPI2DI/SMB4DEN";
+			bias-disable;
+			output-high;
+		};
+		gpio17ol_pins: gpio17ol-pins {
+			pins = "GPIO17/PSPI2DI/SMB4DEN";
+			bias-disable;
+			output-low;
+		};
+		gpio17od_pins: gpio17od-pins {
+			pins = "GPIO17/PSPI2DI/SMB4DEN";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio17pp_pins: gpio17pp-pins {
+			pins = "GPIO17/PSPI2DI/SMB4DEN";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio18_pins: gpio18-pins {
+			pins = "GPIO18/PSPI2D0/SMB4BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio18ol_pins: gpio18ol-pins {
+			pins = "GPIO18/PSPI2D0/SMB4BSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio18od_pins: gpio18od-pins {
+			pins = "GPIO18/PSPI2D0/SMB4BSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio18pp_pins: gpio18pp-pins {
+			pins = "GPIO18/PSPI2D0/SMB4BSDA";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio19_pins: gpio19-pins {
+			pins = "GPIO19/PSPI2CK/SMB4BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio19ol_pins: gpio19ol-pins {
+			pins = "GPIO19/PSPI2CK/SMB4BSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio19od_pins: gpio19od-pins {
+			pins = "GPIO19/PSPI2CK/SMB4BSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio19pp_pins: gpio19pp-pins {
+			pins = "GPIO19/PSPI2CK/SMB4BSCL";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio20_pins: gpio20-pins {
+			pins = "GPIO20/SMB4CSDA/SMB15SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio20o_pins: gpio20o-pins {
+			pins = "GPIO20/SMB4CSDA/SMB15SDA";
+			bias-disable;
+			output-high;
+		};
+		gpio20ol_pins: gpio20ol-pins {
+			pins = "GPIO20/SMB4CSDA/SMB15SDA";
+			bias-disable;
+			output-low;
+		};
+		gpio21_pins: gpio21-pins {
+			pins = "GPIO21/SMB4CSCL/SMB15SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio21ol_pins: gpio21ol-pins {
+			pins = "GPIO21/SMB4CSCL/SMB15SCL";
+			bias-disable;
+			output-low;
+		};
+		gpio22_pins: gpio22-pins {
+			pins = "GPIO22/SMB4DSDA/SMB14SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio22ol_pins: gpio22ol-pins {
+			pins = "GPIO22/SMB4DSDA/SMB14SDA";
+			bias-disable;
+			output-low;
+		};
+		gpio23_pins: gpio23-pins {
+			pins = "GPIO23/SMB4DSCL/SMB14SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio23ol_pins: gpio23ol-pins {
+			pins = "GPIO23/SMB4DSCL/SMB14SCL";
+			bias-disable;
+			output-low;
+		};
+		gpio24_pins: gpio24-pins {
+			pins = "GPIO24/IOXHDO";
+			bias-disable;
+			input-enable;
+		};
+		gpio24o_pins: gpio24o-pins {
+			pins = "GPIO24/IOXHDO";
+			bias-disable;
+			output-high;
+		};
+		gpio24ol_pins: gpio24ol-pins {
+			pins = "GPIO24/IOXHDO";
+			bias-disable;
+			output-low;
+		};
+		gpio24od_pins: gpio24od-pins {
+			pins = "GPIO24/IOXHDO";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio24pp_pins: gpio24pp-pins {
+			pins = "GPIO24/IOXHDO";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio25_pins: gpio25-pins {
+			pins = "GPIO25/IOXHDI";
+			bias-disable;
+			input-enable;
+		};
+		gpio25o_pins: gpio25o-pins {
+			pins = "GPIO25/IOXHDI";
+			bias-disable;
+			output-high;
+		};
+		gpio25ol_pins: gpio25ol-pins {
+			pins = "GPIO25/IOXHDI";
+			bias-disable;
+			output-low;
+		};
+		gpio25od_pins: gpio25od-pins {
+			pins = "GPIO25/IOXHDI";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio25pp_pins: gpio25pp-pins {
+			pins = "GPIO25/IOXHDI";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio26_pins: gpio26-pins {
+			pins = "GPIO26/SMB5SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio27_pins: gpio27-pins {
+			pins = "GPIO27/SMB5SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio32_pins: gpio32-pins {
+			pins = "GPIO32/nSPI0CS1";
+			bias-disable;
+			input-enable;
+		};
+		gpio32o_pins: gpio32o-pins {
+			pins = "GPIO32/nSPI0CS1";
+			bias-disable;
+			output-high;
+		};
+		gpio32ol_pins: gpio32ol-pins {
+			pins = "GPIO32/nSPI0CS1";
+			bias-disable;
+			output-low;
+		};
+		gpio37_pins: gpio37-pins {
+			pins = "GPIO37/SMB3CSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio37o_pins: gpio37o-pins {
+			pins = "GPIO37/SMB3CSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio37ol_pins: gpio37ol-pins {
+			pins = "GPIO37/SMB3CSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio37od_pins: gpio37od-pins {
+			pins = "GPIO37/SMB3CSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio38_pins: gpio38-pins {
+			pins = "GPIO38/SMB3CSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio38o_pins: gpio38o-pins {
+			pins = "GPIO38/SMB3CSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio38ol_pins: gpio38ol-pins {
+			pins = "GPIO38/SMB3CSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio39_pins: gpio39-pins {
+			pins = "GPIO39/SMB3BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio39o_pins: gpio39o-pins {
+			pins = "GPIO39/SMB3BSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio39ol_pins: gpio39ol-pins {
+			pins = "GPIO39/SMB3BSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio40_pins: gpio40-pins {
+			pins = "GPIO40/SMB3BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio40o_pins: gpio40o-pins {
+			pins = "GPIO40/SMB3BSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio40ol_pins: gpio40ol-pins {
+			pins = "GPIO40/SMB3BSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio41_pins: gpio41-pins {
+			pins = "GPIO41/BSPRXD";
+			input-enable;
+		};
+		gpio42_pins: gpio42-pins {
+			pins = "GPO42/BSPTXD/STRAP11";
+			bias-disable;
+			input-enable;
+		};
+		gpio43_pins: gpio43-pins {
+			pins = "GPIO43/RXD1/JTMS2/BU1RXD";
+			bias-disable;
+			input-enable;
+		};
+		gpio44_pins: gpio44-pins {
+			pins = "GPIO44/nCTS1/JTDI2/BU1CTS";
+			bias-disable;
+			input-enable;
+		};
+		gpio45_pins: gpio45-pins {
+			pins = "GPIO45/nDCD1/JTDO2";
+			bias-disable;
+			input-enable;
+		};
+		gpio46_pins: gpio46-pins {
+			pins = "GPIO46/nDSR1/JTCK2";
+			bias-disable;
+			input-enable;
+		};
+		gpio47_pins: gpio47-pins {
+			pins = "GPIO47/nRI1/JCP_RDY2";
+			bias-disable;
+			input-enable;
+		};
+		gpio48_pins: gpio48-pins {
+			pins = "GPIO48/TXD2/BSPTXD";
+			bias-disable;
+			input-enable;
+		};
+		gpio49_pins: gpio49-pins {
+			pins = "GPIO49/RXD2/BSPRXD";
+			bias-disable;
+			input-enable;
+		};
+		gpio50_pins: gpio50-pins {
+			pins = "GPIO50/nCTS2";
+			bias-disable;
+			input-enable;
+		};
+		gpio50ol_pins: gpio50ol-pins {
+			pins = "GPIO50/nCTS2";
+			bias-disable;
+			output-low;
+		};
+		gpio51_pins: gpio51-pins {
+			pins = "GPO51/nRTS2/STRAP2";
+			bias-disable;
+			input-enable;
+		};
+		gpio51o_pins: gpio51o-pins {
+			pins = "GPO51/nRTS2/STRAP2";
+			bias-disable;
+			output-high;
+		};
+		gpio52_pins: gpio52-pins {
+			pins = "GPIO52/nDCD2";
+			bias-disable;
+			input-enable;
+		};
+		gpio52ol_pins: gpio52ol-pins {
+			pins = "GPIO52/nDCD2";
+			bias-disable;
+			output-low;
+		};
+		gpio53_pins: gpio53-pins {
+			pins = "GPO53/nDTR2_BOUT2/STRAP1";
+			bias-disable;
+			input-enable;
+		};
+		gpio53o_pins: gpio53o-pins {
+			pins = "GPO53/nDTR2_BOUT2/STRAP1";
+			bias-disable;
+			output-high;
+		};
+		gpio54_pins: gpio54-pins {
+			pins = "GPIO54/nDSR2";
+			bias-disable;
+			input-enable;
+		};
+		gpio54ol_pins: gpio54ol-pins {
+			pins = "GPIO54/nDSR2";
+			bias-disable;
+			output-low;
+		};
+		gpio55_pins: gpio55-pins {
+			pins = "GPIO55/nRI2";
+			bias-disable;
+			input-enable;
+		};
+		gpio55ol_pins: gpio55ol-pins {
+			pins = "GPIO55/nRI2";
+			bias-disable;
+			output-low;
+		};
+		gpio56_pins: gpio56-pins {
+			pins = "GPIO56/R1RXERR";
+			bias-disable;
+			input-enable;
+		};
+		gpio57_pins: gpio57-pins {
+			pins = "GPIO57/R1MDC";
+			bias-disable;
+			input-enable;
+		};
+		gpio57ol_pins: gpio57ol-pins {
+			pins = "GPIO57/R1MDC";
+			bias-disable;
+			output-low;
+		};
+		gpio58_pins: gpio58-pins {
+			pins = "GPIO58/R1MDIO";
+			bias-disable;
+			input-enable;
+		};
+		gpio58ol_pins: gpio58ol-pins {
+			pins = "GPIO58/R1MDIO";
+			bias-disable;
+			output-low;
+		};
+		gpio59_pins: gpio59-pins {
+			pins = "GPIO59/SMB3DSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio59o_pins: gpio59o-pins {
+			pins = "GPIO59/SMB3DSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio59ol_pins: gpio59ol-pins {
+			pins = "GPIO59/SMB3DSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio59od_pins: gpio59od-pins {
+			pins = "GPIO59/SMB3DSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio59pp_pins: gpio59pp-pins {
+			pins = "GPIO59/SMB3DSDA";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio60_pins: gpio60-pins {
+			pins = "GPIO60/SMB3DSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio60o_pins: gpio60o-pins {
+			pins = "GPIO60/SMB3DSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio60ol_pins: gpio60ol-pins {
+			pins = "GPIO60/SMB3DSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio61_pins: gpio61-pins {
+			pins = "GPO61/nDTR1_BOUT1/STRAP6";
+			bias-disable;
+			input-enable;
+		};
+		gpio61o_pins: gpio61o-pins {
+			pins = "GPO61/nDTR1_BOUT1/STRAP6";
+			bias-disable;
+			output-high;
+		};
+		gpio62_pins: gpio62-pins {
+			pins = "GPO62/nRTST1/STRAP5";
+			bias-disable;
+			input-enable;
+		};
+		gpio62o_pins: gpio62o-pins {
+			pins = "GPO62/nRTST1/STRAP5";
+			bias-disable;
+			output-high;
+		};
+		gpio63_pins: gpio63-pins {
+			pins = "GPO63/TXD1/STRAP4";
+			bias-disable;
+			input-enable;
+		};
+		gpio63o_pins: gpio63o-pins {
+			pins = "GPO63/TXD1/STRAP4";
+			bias-disable;
+			output-high;
+		};
+		gpio64_pins: gpio64-pins {
+			pins = "GPIO64/FANIN0";
+			bias-disable;
+			input-enable;
+		};
+		gpio64o_pins: gpio64o-pins {
+			pins = "GPIO64/FANIN0";
+			bias-disable;
+			output-high;
+		};
+		gpio65_pins: gpio65-pins {
+			pins = "GPIO65/FANIN1";
+			bias-disable;
+			input-enable;
+		};
+		gpio66_pins: gpio66-pins {
+			pins = "GPIO66/FANIN2";
+			bias-disable;
+			input-enable;
+		};
+		gpio67_pins: gpio67-pins {
+			pins = "GPIO67/FANIN3";
+			bias-disable;
+			input-enable;
+		};
+		gpio68_pins: gpio68-pins {
+			pins = "GPIO68/FANIN4";
+			bias-disable;
+			input-enable;
+		};
+		gpio69_pins: gpio69-pins {
+			pins = "GPIO69/FANIN5";
+			bias-disable;
+			input-enable;
+		};
+		gpio69ol_pins: gpio69ol-pins {
+			pins = "GPIO69/FANIN5";
+			bias-disable;
+			output-low;
+		};
+		gpio70_pins: gpio70-pins {
+			pins = "GPIO70/FANIN6";
+			bias-disable;
+			input-enable;
+		};
+		gpio71_pins: gpio71-pins {
+			pins = "GPIO71/FANIN7";
+			bias-disable;
+			input-enable;
+		};
+		gpio72_pins: gpio72-pins {
+			pins = "GPIO72/FANIN8";
+			bias-disable;
+			input-enable;
+		};
+		gpio72o_pins: gpio72o-pins {
+			pins = "GPIO72/FANIN8";
+			bias-disable;
+			output-high;
+		};
+		gpio72ol_pins: gpio72ol-pins {
+			pins = "GPIO72/FANIN8";
+			bias-disable;
+			output-low;
+		};
+		gpio72od_pins: gpio72od-pins {
+			pins = "GPIO72/FANIN8";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio73_pins: gpio73-pins {
+			pins = "GPIO73/FANIN9";
+			bias-disable;
+			input-enable;
+		};
+		gpio73o_pins: gpio73o-pins {
+			pins = "GPIO73/FANIN9";
+			bias-disable;
+			output-high;
+		};
+		gpio73ol_pins: gpio73ol-pins {
+			pins = "GPIO73/FANIN9";
+			bias-disable;
+			output-low;
+		};
+		gpio73od_pins: gpio73od-pins {
+			pins = "GPIO73/FANIN9";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio74_pins: gpio74-pins {
+			pins = "GPIO74/FANIN10";
+			bias-disable;
+			input-enable;
+		};
+		gpio74o_pins: gpio74o-pins {
+			pins = "GPIO74/FANIN10";
+			bias-disable;
+			output-high;
+		};
+		gpio74ol_pins: gpio74ol-pins {
+			pins = "GPIO74/FANIN10";
+			bias-disable;
+			output-low;
+		};
+		gpio74od_pins: gpio74od-pins {
+			pins = "GPIO74/FANIN10";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio75_pins: gpio75-pins {
+			pins = "GPIO75/FANIN11";
+			bias-disable;
+			input-enable;
+		};
+		gpio75o_pins: gpio75o-pins {
+			pins = "GPIO75/FANIN11";
+			bias-disable;
+			output-high;
+		};
+		gpio75ol_pins: gpio75ol-pins {
+			pins = "GPIO75/FANIN11";
+			bias-disable;
+			output-low;
+		};
+		gpio75od_pins: gpio75od-pins {
+			pins = "GPIO75/FANIN11";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio76_pins: gpio76-pins {
+			pins = "GPIO76/FANIN12";
+			bias-disable;
+			input-enable;
+		};
+		gpio76o_pins: gpio76o-pins {
+			pins = "GPIO76/FANIN12";
+			bias-disable;
+			output-high;
+		};
+		gpio76ol_pins: gpio76ol-pins {
+			pins = "GPIO76/FANIN12";
+			bias-disable;
+			output-low;
+		};
+		gpio76od_pins: gpio76od-pins {
+			pins = "GPIO76/FANIN12";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio77_pins: gpio77-pins {
+			pins = "GPIO77/FANIN13";
+			bias-disable;
+			input-enable;
+		};
+		gpio77o_pins: gpio77o-pins {
+			pins = "GPIO77/FANIN13";
+			bias-disable;
+			output-high;
+		};
+		gpio77ol_pins: gpio77ol-pins {
+			pins = "GPIO77/FANIN13";
+			bias-disable;
+			output-low;
+		};
+		gpio77od_pins: gpio77od-pins {
+			pins = "GPIO77/FANIN13";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio78_pins: gpio78-pins {
+			pins = "GPIO78/FANIN14";
+			bias-disable;
+			input-enable;
+		};
+		gpio78o_pins: gpio78o-pins {
+			pins = "GPIO78/FANIN14";
+			bias-disable;
+			output-high;
+		};
+		gpio78ol_pins: gpio78ol-pins {
+			pins = "GPIO78/FANIN14";
+			bias-disable;
+			output-low;
+		};
+		gpio78od_pins: gpio78od-pins {
+			pins = "GPIO78/FANIN14";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio79_pins: gpio79-pins {
+			pins = "GPIO79/FANIN15";
+			bias-disable;
+			input-enable;
+		};
+		gpio79o_pins: gpio79o-pins {
+			pins = "GPIO79/FANIN15";
+			bias-disable;
+			output-high;
+		};
+		gpio79ol_pins: gpio79ol-pins {
+			pins = "GPIO79/FANIN15";
+			bias-disable;
+			output-low;
+		};
+		gpio79od_pins: gpio79od-pins {
+			pins = "GPIO79/FANIN15";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio80_pins: gpio80-pins {
+			pins = "GPIO80/PWM0";
+			bias-disable;
+			input-enable;
+		};
+		gpio81_pins: gpio81-pins {
+			pins = "GPIO81/PWM1";
+			bias-disable;
+			input-enable;
+		};
+		gpio82_pins: gpio82-pins {
+			pins = "GPIO82/PWM2";
+			bias-disable;
+			input-enable;
+		};
+		gpio83_pins: gpio83-pins {
+			pins = "GPIO83/PWM3";
+			bias-disable;
+			input-enable;
+		};
+		gpio84_pins: gpio84-pins {
+			pins = "GPIO84/R2TXD0";
+			bias-disable;
+			input-enable;
+		};
+		gpio84o_pins: gpio84o-pins {
+			pins = "GPIO84/R2TXD0";
+			bias-disable;
+			output-high;
+		};
+		gpio84ol_pins: gpio84ol-pins {
+			pins = "GPIO84/R2TXD0";
+			bias-disable;
+			output-low;
+		};
+		gpio84od_pins: gpio84od-pins {
+			pins = "GPIO84/R2TXD0";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio84pp_pins: gpio84pp-pins {
+			pins = "GPIO84/R2TXD0";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio85_pins: gpio85-pins {
+			pins = "GPIO85/R2TXD1";
+			bias-disable;
+			input-enable;
+		};
+		gpio85o_pins: gpio85o-pins {
+			pins = "GPIO85/R2TXD1";
+			bias-disable;
+			output-high;
+		};
+		gpio85ol_pins: gpio85ol-pins {
+			pins = "GPIO85/R2TXD1";
+			bias-disable;
+			output-low;
+		};
+		gpio85od_pins: gpio85od-pins {
+			pins = "GPIO85/R2TXD1";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio85pp_pins: gpio85pp-pins {
+			pins = "GPIO85/R2TXD1";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio86_pins: gpio86-pins {
+			pins = "GPIO86/R2TXEN";
+			bias-disable;
+			input-enable;
+		};
+		gpio86o_pins: gpio86o-pins {
+			pins = "GPIO86/R2TXEN";
+			bias-disable;
+			output-high;
+		};
+		gpio86ol_pins: gpio86ol-pins {
+			pins = "GPIO86/R2TXEN";
+			bias-disable;
+			output-low;
+		};
+		gpio86od_pins: gpio86od-pins {
+			pins = "GPIO86/R2TXEN";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio86pp_pins: gpio86pp-pins {
+			pins = "GPIO86/R2TXEN";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio87_pins: gpio87-pins {
+			pins = "GPIO87/R2RXD0";
+			bias-disable;
+			input-enable;
+		};
+		gpio87o_pins: gpio87o-pins {
+			pins = "GPIO87/R2RXD0";
+			bias-disable;
+			output-high;
+		};
+		gpio87ol_pins: gpio87ol-pins {
+			pins = "GPIO87/R2RXD0";
+			bias-disable;
+			output-low;
+		};
+		gpio87od_pins: gpio87od-pins {
+			pins = "GPIO87/R2RXD0";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio87pp_pins: gpio87pp-pins {
+			pins = "GPIO87/R2RXD0";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio88_pins: gpio88-pins {
+			pins = "GPIO88/R2RXD1";
+			bias-disable;
+			input-enable;
+		};
+		gpio88ol_pins: gpio88ol-pins {
+			pins = "GPIO88/R2RXD1";
+			bias-disable;
+			output-low;
+		};
+		gpio88od_pins: gpio88od-pins {
+			pins = "GPIO88/R2RXD1";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio88pp_pins: gpio88pp-pins {
+			pins = "GPIO88/R2RXD1";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio89_pins: gpio89-pins {
+			pins = "GPIO89/R2CRSDV";
+			bias-disable;
+			input-enable;
+		};
+		gpio89ol_pins: gpio89ol-pins {
+			pins = "GPIO89/R2CRSDV";
+			bias-disable;
+			output-low;
+		};
+		gpio89od_pins: gpio89od-pins {
+			pins = "GPIO89/R2CRSDV";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio89pp_pins: gpio89pp-pins {
+			pins = "GPIO89/R2CRSDV";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio90_pins: gpio90-pins {
+			pins = "GPIO90/R2RXERR";
+			bias-disable;
+			input-enable;
+		};
+		gpio90o_pins: gpio90o0-pins {
+			pins = "GPIO90/R2RXERR";
+			bias-disable;
+			output-high;
+		};
+		gpio90ol_pins: gpio90ol-pins {
+			pins = "GPIO90/R2RXERR";
+			bias-disable;
+			output-low;
+		};
+		gpio90od_pins: gpio90od-pins {
+			pins = "GPIO90/R2RXERR";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio90pp_pins: gpio90pp-pins {
+			pins = "GPIO90/R2RXERR";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio91_pins: gpio91-pins {
+			pins = "GPIO91/R2MDC";
+			bias-disable;
+			input-enable;
+		};
+		gpio91o_pins: gpio91o-pins {
+			pins = "GPIO91/R2MDC";
+			bias-disable;
+			output-high;
+		};
+		gpio91ol_pins: gpio91ol-pins {
+			pins = "GPIO91/R2MDC";
+			bias-disable;
+			output-low;
+		};
+		gpio92_pins: gpio92-pins {
+			pins = "GPIO92/R2MDIO";
+			bias-disable;
+			input-enable;
+		};
+		gpio92o_pins: gpio92o-pins {
+			pins = "GPIO92/R2MDIO";
+			bias-disable;
+			output-high;
+		};
+		gpio92ol_pins: gpio92ol-pins {
+			pins = "GPIO92/R2MDIO";
+			bias-disable;
+			output-low;
+		};
+		gpio93_pins: gpio93-pins {
+			pins = "GPIO93/GA20/SMB5DSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio93ol_pins: gpio93ol-pins {
+			pins = "GPIO93/GA20/SMB5DSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio93od_pins: gpio93od-pins {
+			pins = "GPIO93/GA20/SMB5DSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio93pp_pins: gpio93pp-pins {
+			pins = "GPIO93/GA20/SMB5DSCL";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio94_pins: gpio94-pins {
+			pins = "GPIO94/nKBRST/SMB5DSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio94o_pins: gpio94o-pins {
+			pins = "GPIO94/nKBRST/SMB5DSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio94ol_pins: gpio94ol-pins {
+			pins = "GPIO94/nKBRST/SMB5DSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio94od_pins: gpio94od-pins {
+			pins = "GPIO94/nKBRST/SMB5DSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio94pp_pins: gpio94pp-pins {
+			pins = "GPIO94/nKBRST/SMB5DSDA";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio95_pins: gpio95-pins {
+			pins = "GPIO95/nLRESET/nESPIRST";
+			bias-disable;
+			input-enable;
+		};
+		gpio96_pins: gpio96-pins {
+			pins = "GPIO96/RG1TXD0";
+			bias-disable;
+			input-enable;
+		};
+		gpio96ol_pins: gpio96ol-pins {
+			pins = "GPIO96/RG1TXD0";
+			bias-disable;
+			output-low;
+		};
+		gpio97_pins: gpio97-pins {
+			pins = "GPIO97/RG1TXD1";
+			bias-disable;
+			input-enable;
+		};
+		gpio97ol_pins: gpio97ol-pins {
+			pins = "GPIO97/RG1TXD1";
+			bias-disable;
+			output-low;
+		};
+		gpio98_pins: gpio98-pins {
+			pins = "GPIO98/RG1TXD2";
+			bias-disable;
+			input-enable;
+		};
+		gpio98ol_pins: gpio98ol-pins {
+			pins = "GPIO98/RG1TXD2";
+			bias-disable;
+			output-low;
+		};
+		gpio99_pins: gpio99-pins {
+			pins = "GPIO99/RG1TXD3";
+			bias-disable;
+			input-enable;
+		};
+		gpio99ol_pins: gpio99ol-pins {
+			pins = "GPIO99/RG1TXD3";
+			bias-disable;
+			output-low;
+		};
+		gpio100_pins: gpio100-pins {
+			pins = "GPIO100/RG1TXC";
+			bias-disable;
+			input-enable;
+		};
+		gpio100ol_pins: gpio100ol-pins {
+			pins = "GPIO100/RG1TXC";
+			bias-disable;
+			output-low;
+		};
+		gpio101_pins: gpio101-pins {
+			pins = "GPIO101/RG1TXCTL";
+			bias-disable;
+			input-enable;
+		};
+		gpio101ol_pins: gpio101ol-pins {
+			pins = "GPIO101/RG1TXCTL";
+			bias-disable;
+			output-low;
+		};
+		gpio102_pins: gpio102-pins {
+			pins = "GPIO102/RG1RXD0";
+			bias-disable;
+			input-enable;
+		};
+		gpio102ol_pins: gpio102ol-pins {
+			pins = "GPIO102/RG1RXD0";
+			bias-disable;
+			output-low;
+		};
+		gpio103_pins: gpio103-pins {
+			pins = "GPIO103/RG1RXD1";
+			bias-disable;
+			input-enable;
+		};
+		gpio103ol_pins: gpio103ol-pins {
+			pins = "GPIO103/RG1RXD1";
+			bias-disable;
+			output-low;
+		};
+		gpio104_pins: gpio104-pins {
+			pins = "GPIO104/RG1RXD2";
+			bias-disable;
+			input-enable;
+		};
+		gpio104ol_pins: gpio104ol-pins {
+			pins = "GPIO104/RG1RXD2";
+			bias-disable;
+			output-low;
+		};
+		gpio105_pins: gpio105-pins {
+			pins = "GPIO105/RG1RXD3";
+			bias-disable;
+			input-enable;
+		};
+		gpio105ol_pins: gpio105ol-pins {
+			pins = "GPIO105/RG1RXD3";
+			bias-disable;
+			output-low;
+		};
+		gpio106_pins: gpio106-pins {
+			pins = "GPIO106/RG1RXC";
+			bias-disable;
+			input-enable;
+		};
+		gpio106ol_pins: gpio106ol-pins {
+			pins = "GPIO106/RG1RXC";
+			bias-disable;
+			output-low;
+		};
+		gpio107_pins: gpio107-pins {
+			pins = "GPIO107/RG1RXCTL";
+			bias-disable;
+			input-enable;
+		};
+		gpio107ol_pins: gpio107ol-pins {
+			pins = "GPIO107/RG1RXCTL";
+			bias-disable;
+			output-low;
+		};
+		gpio108_pins: gpio108-pins {
+			pins = "GPIO108/RG1MDC";
+			bias-disable;
+			input-enable;
+		};
+		gpio108ol_pins: gpio108ol-pins {
+			pins = "GPIO108/RG1MDC";
+			bias-disable;
+			output-low;
+		};
+		gpio109_pins: gpio109-pins {
+			pins = "GPIO109/RG1MDIO";
+			bias-disable;
+			input-enable;
+		};
+		gpio109ol_pins: gpio109ol-pins {
+			pins = "GPIO109/RG1MDIO";
+			bias-disable;
+			output-low;
+		};
+		gpio110_pins: gpio110-pins {
+			pins = "GPIO110/RG2TXD0/DDRV0";
+			bias-disable;
+			input-enable;
+		};
+		gpio110ol_pins: gpio110ol-pins {
+			pins = "GPIO110/RG2TXD0/DDRV0";
+			bias-disable;
+			output-low;
+		};
+		gpio111_pins: gpio111-pins {
+			pins = "GPIO111/RG2TXD1/DDRV1";
+			bias-disable;
+			input-enable;
+		};
+		gpio111ol_pins: gpio111ol-pins {
+			pins = "GPIO111/RG2TXD1/DDRV1";
+			bias-disable;
+			output-low;
+		};
+		gpio112_pins: gpio112-pins {
+			pins = "GPIO112/RG2TXD2/DDRV2";
+			bias-disable;
+			input-enable;
+		};
+		gpio112ol_pins: gpio112ol-pins {
+			pins = "GPIO112/RG2TXD2/DDRV2";
+			bias-disable;
+			output-low;
+		};
+		gpio113_pins: gpio113-pins {
+			pins = "GPIO113/RG2TXD3/DDRV3";
+			bias-disable;
+			input-enable;
+		};
+		gpio113ol_pins: gpio113ol-pins {
+			pins = "GPIO113/RG2TXD3/DDRV3";
+			bias-disable;
+			output-low;
+		};
+		gpio118_pins: gpio118-pins {
+			pins = "GPIO118/SMB2SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio119_pins: gpio119-pins {
+			pins = "GPIO119/SMB2SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio120_pins: gpio120-pins {
+			pins = "GPIO120/SMB2CSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio121_pins: gpio121-pins {
+			pins = "GPIO121/SMB2CSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio122_pins: gpio122-pins {
+			pins = "GPIO122/SMB2BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio123_pins: gpio123-pins {
+			pins = "GPIO123/SMB2BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio123_pins: gpio123-pins {
+			pins = "GPIO123/SMB2BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio124_pins: gpio124-pins {
+			pins = "GPIO124/SMB1CSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio125_pins: gpio125-pins {
+			pins = "GPIO125/SMB1CSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio125ol_pins: gpio125ol-pins {
+			pins = "GPIO125/SMB1CSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio125od_pins: gpio125od-pins {
+			pins = "GPIO125/SMB1CSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio125pp_pins: gpio125pp-pins {
+			pins = "GPIO125/SMB1CSCL";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio126_pins: gpio126-pins {
+			pins = "GPIO126/SMB1BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio126o_pins: gpio126o-pins {
+			pins = "GPIO126/SMB1BSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio126ol_pins: gpio126ol-pins {
+			pins = "GPIO126/SMB1BSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio126od_pins: gpio126od-pins {
+			pins = "GPIO126/SMB1BSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio127_pins: gpio127-pins {
+			pins = "GPIO127/SMB1BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio127o_pins: gpio127o-pins {
+			pins = "GPIO127/SMB1BSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio127od_pins: gpio127od-pins {
+			pins = "GPIO127/SMB1BSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio128o_pins: gpio128o-pins {
+			pins = "GPIO128/SMB8SCL";
+			bias-disable;
+			output-high;
+		};
+		gpio130_pins: gpio130-pins {
+			pins = "GPIO130/SMB9SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio131_pins: gpio131-pins {
+			pins = "GPIO131/SMB9SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio132_pins: gpio132-pins {
+			pins = "GPIO132/SMB10SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio133_pins: gpio133-pins {
+			pins = "GPIO133/SMB10SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio134_pins: gpio134-pins {
+			pins = "GPIO134/SMB11SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio135_pins: gpio135-pins {
+			pins = "GPIO135/SMB11SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio136_pins: gpio136-pins {
+			pins = "GPIO136/SD1DT0";
+			bias-disable;
+			input-enable;
+		};
+		gpio136o_pins: gpio136o-pins {
+			pins = "GPIO136/SD1DT0";
+			bias-disable;
+			output-high;
+		};
+		gpio137_pins: gpio137-pins {
+			pins = "GPIO137/SD1DT1";
+			bias-disable;
+			input-enable;
+		};
+		gpio137o_pins: gpio137o-pins {
+			pins = "GPIO137/SD1DT1";
+			bias-disable;
+			output-high;
+		};
+		gpio138_pins: gpio138-pins {
+			pins = "GPIO138/SD1DT2";
+			bias-disable;
+			input-enable;
+		};
+		gpio138o_pins: gpio138o-pins {
+			pins = "GPIO138/SD1DT2";
+			bias-disable;
+			output-high;
+		};
+		gpio139_pins: gpio139-pins {
+			pins = "GPIO139/SD1DT3";
+			bias-disable;
+			input-enable;
+		};
+		gpio139o_pins: gpio139o-pins {
+			pins = "GPIO139/SD1DT3";
+			bias-disable;
+			output-high;
+		};
+		gpio140_pins: gpio140-pins {
+			pins = "GPIO140/SD1CLK";
+			bias-disable;
+			input-enable;
+		};
+		gpio140o_pins: gpio140o-pins {
+			pins = "GPIO140/SD1CLK";
+			bias-disable;
+			output-high;
+		};
+		gpio141_pins: gpio141-pins {
+			pins = "GPIO141/SD1WP";
+			bias-disable;
+			input-enable;
+		};
+		gpio141o_pins: gpio141o-pins {
+			pins = "GPIO141/SD1WP";
+			bias-disable;
+			output-high;
+		};
+		gpio142_pins: gpio142-pins {
+			pins = "GPIO142/SD1CMD";
+			bias-disable;
+			input-enable;
+		};
+		gpio142o_pins: gpio142o-pins {
+			pins = "GPIO142/SD1CMD";
+			bias-disable;
+			output-high;
+		};
+		gpio142ol_pins: gpio142ol-pins {
+			pins = "GPIO142/SD1CMD";
+			bias-disable;
+			output-low;
+		};
+		gpio142od_pins: gpio142od-pins {
+			pins = "GPIO142/SD1CMD";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio143_pins: gpio143-pins {
+			pins = "GPIO143/SD1CD/SD1PWR";
+			bias-disable;
+			input-enable;
+		};
+		gpio143o_pins: gpio143o-pins {
+			pins = "GPIO143/SD1CD/SD1PWR";
+			bias-disable;
+			output-high;
+		};
+		gpio143ol_pins: gpio143ol-pins {
+			pins = "GPIO143/SD1CD/SD1PWR";
+			bias-disable;
+			output-low;
+		};
+		gpio143od_pins: gpio143od-pins {
+			pins = "GPIO143/SD1CD/SD1PWR";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio144_pins: gpio144-pins {
+			pins = "GPIO144/PWM4";
+			bias-disable;
+			input-enable;
+		};
+		gpio144o_pins: gpio144o-pins {
+			pins = "GPIO144/PWM4";
+			bias-disable;
+			output-high;
+		};
+		gpio145_pins: gpio145-pins {
+			pins = "GPIO145/PWM5";
+			bias-disable;
+			input-enable;
+		};
+		gpio145o_pins: gpio145o-pins {
+			pins = "GPIO145/PWM5";
+			bias-disable;
+			output-high;
+		};
+		gpio146_pins: gpio146-pins {
+			pins = "GPIO146/PWM6";
+			bias-disable;
+			input-enable;
+		};
+		gpio146o_pins: gpio146o-pins {
+			pins = "GPIO146/PWM6";
+			bias-disable;
+			output-high;
+		};
+		gpio147_pins: gpio147-pins {
+			pins = "GPIO147/PWM7";
+			bias-disable;
+			input-enable;
+		};
+		gpio148_pins: gpio148-pins {
+			pins = "GPIO148/MMCDT4";
+			bias-disable;
+			input-enable;
+		};
+		gpio148o_pins: gpio148o-pins {
+			pins = "GPIO148/MMCDT4";
+			bias-disable;
+			output-high;
+		};
+		gpio148ol_pins: gpio148ol_pins {
+			pins = "GPIO148/MMCDT4";
+			bias-disable;
+			output-low;
+		};
+		gpio149_pins: gpio149-pins {
+			pins = "GPIO149/MMCDT5";
+			bias-disable;
+			input-enable;
+		};
+		gpio149o_pins: gpio149o-pins {
+			pins = "GPIO149/MMCDT5";
+			bias-disable;
+			output-high;
+		};
+		gpio149ol_pins: gpio149ol-pins {
+			pins = "GPIO149/MMCDT5";
+			bias-disable;
+			output-low;
+		};
+		gpio150_pins: gpio150-pins {
+			pins = "GPIO150/MMCDT6";
+			bias-disable;
+			input-enable;
+		};
+		gpio150o_pins: gpio150o-pins {
+			pins = "GPIO150/MMCDT6";
+			bias-disable;
+			output-high;
+		};
+		gpio150ol_pins: gpio150ol-pins {
+			pins = "GPIO150/MMCDT6";
+			bias-disable;
+			output-low;
+		};
+		gpio151_pins: gpio151-pins {
+			pins = "GPIO151/MMCDT7";
+			bias-disable;
+			input-enable;
+		};
+		gpio151o_pins: gpio151o-pins {
+			pins = "GPIO151/MMCDT7";
+			bias-disable;
+			output-high;
+		};
+		gpio151ol_pins: gpio151ol-pins {
+			pins = "GPIO151/MMCDT7";
+			bias-disable;
+			output-low;
+		};
+		gpio152_pins: gpio152-pins {
+			pins = "GPIO152/MMCCLK";
+			bias-disable;
+			input-enable;
+		};
+		gpio152o_pins: gpio152o-pins {
+			pins = "GPIO152/MMCCLK";
+			bias-disable;
+			output-high;
+		};
+		gpio152ol_pins: gpio152ol-pins {
+			pins = "GPIO152/MMCCLK";
+			bias-disable;
+			output-low;
+		};
+		gpio153_pins: gpio153-pins {
+			pins = "GPIO153/MMCWP";
+			bias-disable;
+			input-enable;
+		};
+		gpio153ol_pins: gpio153ol-pins {
+			pins = "GPIO153/MMCWP";
+			bias-disable;
+			output-low;
+		};
+		gpio154_pins: gpio154-pins {
+			pins = "GPIO154/MMCCMD";
+			bias-disable;
+			input-enable;
+		};
+		gpio154ol_pins: gpio154ol-pins {
+			pins = "GPIO154/MMCCMD";
+			bias-disable;
+			output-low;
+		};
+		gpio155_pins: gpio155-pins {
+			pins = "GPIO155/nMMCCD/nMMCRST";
+			bias-disable;
+			input-enable;
+		};
+		gpio155ol_pins: gpio155ol-pins {
+			pins = "GPIO155/nMMCCD/nMMCRST";
+			bias-disable;
+			output-low;
+		};
+		gpio156_pins: gpio156-pins {
+			pins = "GPIO156/MMCDT0";
+			bias-disable;
+			input-enable;
+		};
+		gpio156ol_pins: gpio156ol-pins {
+			pins = "GPIO156/MMCDT0";
+			bias-disable;
+			output-low;
+		};
+		gpio157_pins: gpio157-pins {
+			pins = "GPIO157/MMCDT1";
+			bias-disable;
+			input-enable;
+		};
+		gpio157o_pins: gpio157o-pins {
+			pins = "GPIO157/MMCDT1";
+			bias-disable;
+			output-high;
+		};
+		gpio157ol_pins: gpio157ol-pins {
+			pins = "GPIO157/MMCDT1";
+			bias-disable;
+			output-low;
+		};
+		gpio158_pins: gpio158-pins {
+			pins = "GPIO158/MMCDT2";
+			bias-disable;
+			input-enable;
+		};
+		gpio158o_pins: gpio158o-pins {
+			pins = "GPIO158/MMCDT2";
+			bias-disable;
+			output-high;
+		};
+		gpio158ol_pins: gpio158ol-pins {
+			pins = "GPIO158/MMCDT2";
+			bias-disable;
+			output-low;
+		};
+		gpio159_pins: gpio159-pins {
+			pins = "GPIO159/MMCDT3";
+			bias-disable;
+			input-enable;
+		};
+		gpio159o_pins: gpio159o-pins {
+			pins = "GPIO159/MMCDT3";
+			bias-disable;
+			output-high;
+		};
+		gpio159ol_pins: gpio159ol-pins {
+			pins = "GPIO159/MMCDT3";
+			bias-disable;
+			output-low;
+		};
+		gpio160_pins: gpio160-pins {
+			pins = "GPIO160/CLKOUT/RNGOSCOUT";
+			bias-disable;
+			input-enable;
+		};
+		gpio160o_pins: gpio160o-pins {
+			pins = "GPIO160/CLKOUT/RNGOSCOUT";
+			bias-disable;
+			output-high;
+		};
+		gpio160ol_pins: gpio160ol-pins {
+			pins = "GPIO160/CLKOUT/RNGOSCOUT";
+			bias-disable;
+			output-low;
+		};
+		gpio161_pins: gpio161-pins {
+			pins = "GPIO161/nLFRAME/nESPICS";
+			bias-disable;
+			input-enable;
+		};
+		gpio162_pins: gpio162-pins {
+			pins = "GPIO162/SERIRQ";
+			bias-disable;
+			input-enable;
+		};
+		gpio163_pins: gpio163-pins {
+			pins = "GPIO163/LCLK/ESPICLK";
+			bias-disable;
+			input-enable;
+		};
+		gpio164_pins: gpio164-pins {
+			pins = "GPIO164/LAD0/ESPI_IO0";
+			bias-disable;
+			input-enable;
+		};
+		gpio165_pins: gpio165-pins {
+			pins = "GPIO165/LAD1/ESPI_IO1";
+			bias-disable;
+			input-enable;
+		};
+		gpio166_pins: gpio166-pins {
+			pins = "GPIO166/LAD2/ESPI_IO2";
+			bias-disable;
+			input-enable;
+		};
+		gpio167_pins: gpio167-pins {
+			pins = "GPIO167/LAD3/ESPI_IO3";
+			bias-disable;
+			input-enable;
+		};
+		gpio168_pins: gpio168-pins {
+			pins = "GPIO168/nCLKRUN/nESPIALERT";
+			bias-disable;
+			input-enable;
+		};
+		gpio168ol_pins: gpio168ol-pins {
+			pins = "GPIO168/nCLKRUN/nESPIALERT";
+			bias-disable;
+			output-low;
+		};
+		gpio169_pins: gpio169-pins {
+			pins = "GPIO169/nSCIPME";
+			bias-disable;
+			input-enable;
+		};
+		gpio169o_pins: gpio169o-pins {
+			pins = "GPIO169/nSCIPME";
+			bias-disable;
+			output-high;
+		};
+		gpio169ol_pins: gpio169ol-pins {
+			pins = "GPIO169/nSCIPME";
+			bias-disable;
+			output-low;
+		};
+		gpio170_pins: gpio170-pins {
+			pins = "GPIO170/nSMI";
+			bias-disable;
+			input-enable;
+		};
+		gpio170ol_pins: gpio170ol-pins {
+			pins = "GPIO170/nSMI";
+			bias-disable;
+			output-low;
+		};
+		gpio173o_pins: gpio173o-pins {
+			pins = "GPIO173/SMB7SCL";
+			bias-disable;
+			output-high;
+		};
+		gpio173ol_pins: gpio173ol-pins {
+			pins = "GPIO173/SMB7SCL";
+			bias-disable;
+			output-low;
+		};
+		gpio174_pins: gpio174-pins {
+			pins = "GPIO174/SMB7SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio175_pins: gpio175-pins {
+			pins = "GPIO175/PSPI1CK/FANIN19";
+			bias-disable;
+			input-enable;
+		};
+		gpio175o_pins: gpio175o-pins {
+			pins = "GPIO175/PSPI1CK/FANIN19";
+			bias-disable;
+			output-high;
+		};
+		gpio175ol_pins: gpio175ol-pins {
+			pins = "GPIO175/PSPI1CK/FANIN19";
+			bias-disable;
+			output-low;
+		};
+		gpio175od_pins: gpio175od-pins {
+			pins = "GPIO175/PSPI1CK/FANIN19";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio176_pins: gpio176-pins {
+			pins = "GPIO176/PSPI1DO/FANIN18";
+			bias-disable;
+			input-enable;
+		};
+		gpio176o_pins: gpio176o-pins {
+			pins = "GPIO176/PSPI1DO/FANIN18";
+			bias-disable;
+			output-high;
+		};
+		gpio176ol_pins: gpio176ol-pins {
+			pins = "GPIO176/PSPI1DO/FANIN18";
+			bias-disable;
+			output-low;
+		};
+		gpio176od_pins: gpio176od-pins {
+			pins = "GPIO176/PSPI1DO/FANIN18";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio177_pins: gpio177-pins {
+			pins = "GPIO177/PSPI1DI/FANIN17";
+			bias-disable;
+			input-enable;
+		};
+		gpio177o_pins: gpio177o-pins {
+			pins = "GPIO177/PSPI1DI/FANIN17";
+			bias-disable;
+			output-high;
+		};
+		gpio177ol_pins: gpio177ol-pins {
+			pins = "GPIO177/PSPI1DI/FANIN17";
+			bias-disable;
+			output-low;
+		};
+		gpio187_pins: gpio187-pins {
+			pins = "GPIO187/nSPI3CS1";
+			bias-disable;
+			input-enable;
+		};
+		gpio187o_pins: gpio187o-pins {
+			pins = "GPIO187/nSPI3CS1";
+			bias-disable;
+			output-high;
+		};
+		gpio187ol_pins: gpio187ol-pins {
+			pins = "GPIO187/nSPI3CS1";
+			bias-disable;
+			output-low;
+		};
+		gpio188_pins: gpio188-pins {
+			pins = "GPIO188/SPI3D2/nSPI3CS2";
+			bias-disable;
+			input-enable;
+		};
+		gpio188o_pins: gpio188o-pins {
+			pins = "GPIO188/SPI3D2/nSPI3CS2";
+			bias-disable;
+			output-high;
+		};
+		gpio189o_pins: gpio189o-pins {
+			pins = "GPIO189/SPI3D3/nSPI3CS3";
+			bias-disable;
+			output-high;
+		};
+		gpio190_pins: gpio190-pins {
+			pins = "GPIO190/nPRD_SMI";
+			bias-disable;
+			input-enable;
+		};
+		gpio190o_pins: gpio190o-pins {
+			pins = "GPIO190/nPRD_SMI";
+			bias-disable;
+			output-high;
+		};
+		gpio190ol_pins: gpio190ol-pins {
+			pins = "GPIO190/nPRD_SMI";
+			bias-disable;
+			output-low;
+		};
+		gpio190od_pins: gpio190od-pins {
+			pins = "GPIO190/nPRD_SMI";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio191_pins: gpio191-pins {
+			pins = "GPIO191";
+			bias-disable;
+			input-enable;
+		};
+		gpio191o_pins: gpio191o-pins {
+			pins = "GPIO191";
+			bias-disable;
+			output-high;
+		};
+		gpio191ol_pins: gpio191ol-pins {
+			pins = "GPIO191";
+			bias-disable;
+			output-low;
+		};
+		gpio192_pins: gpio192-pins {
+			pins = "GPIO192";
+			bias-disable;
+			input-enable;
+		};
+		gpio192o_pins: gpio192o-pins {
+			pins = "GPIO192";
+			bias-disable;
+			output-high;
+		};
+		gpio192ol_pins: gpio192ol-pins {
+			pins = "GPIO192";
+			bias-disable;
+			output-low;
+		};
+		gpio194_pins: gpio194-pins {
+			pins = "GPIO194/SMB0BSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio194o_pins: gpio194o-pins {
+			pins = "GPIO194/SMB0BSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio194ol_pins: gpio194ol-pins {
+			pins = "GPIO194/SMB0BSCL";
+			bias-disable;
+			output-low;
+		};
+		gpio194od_pins: gpio194od-pins {
+			pins = "GPIO194/SMB0BSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio194pp_pins: gpio194pp-pins {
+			pins = "GPIO194/SMB0BSCL";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio195_pins: gpio195-pins {
+			pins = "GPIO195/SMB0BSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio195o_pins: gpio195o-pins {
+			pins = "GPIO195/SMB0BSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio195od_pins: gpio195od-pins {
+			pins = "GPIO195/SMB0BSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio196_pins: gpio196-pins {
+			pins = "GPIO196/SMB0CSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio196o_pins: gpio196o-pins {
+			pins = "GPIO196/SMB0CSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio196od_pins: gpio196od-pins {
+			pins = "GPIO196/SMB0CSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio197_pins: gpio197-pins {
+			pins = "GPIO197/SMB0DEN";
+			bias-disable;
+			input-enable;
+		};
+		gpio197o_pins: gpio197o-pins {
+			pins = "GPIO197/SMB0DEN";
+			bias-disable;
+			output-high;
+		};
+		gpio197ol_pins: gpio197ol-pins {
+			pins = "GPIO197/SMB0DEN";
+			bias-disable;
+			output-low;
+		};
+		gpio197od_pins: gpio197od-pins {
+			pins = "GPIO197/SMB0DEN";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio198o_pins: gpio198o-pins {
+			pins = "GPIO198/SMB0DSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio198ol_pins: gpio198ol-pins {
+			pins = "GPIO198/SMB0DSDA";
+			bias-disable;
+			output-low;
+		};
+		gpio198od_pins: gpio198od-pins {
+			pins = "GPIO198/SMB0DSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio199_pins: gpio199-pins {
+			pins = "GPIO199/SMB0DSCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio199o_pins: gpio199o-pins {
+			pins = "GPIO199/SMB0DSCL";
+			bias-disable;
+			output-high;
+		};
+		gpio199od_pins: gpio199od-pins {
+			pins = "GPIO199/SMB0DSCL";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio200_pins: gpio200-pins {
+			pins = "GPIO200/R2CK";
+			input-enable;
+			bias-disable;
+		};
+		gpio200o_pins: gpio200o-pins {
+			pins = "GPIO200/R2CK";
+			bias-disable;
+			output-high;
+		};
+		gpio200ol_pins: gpio200ol-pins {
+			pins = "GPIO200/R2CK";
+			bias-disable;
+			output-low;
+		};
+		gpio200od_pins: gpio200od-pins {
+			pins = "GPIO200/R2CK";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio200pp_pins: gpio200pp-pins {
+			pins = "GPIO200/R2CK";
+			bias-disable;
+			drive-push-pull;
+		};
+		gpio201ol_pins: gpio201ol-pins {
+			pins = "GPIO200/R2CK";
+			bias-disable;
+			output-low;
+		};
+		gpio202_pins: gpio202-pins {
+			pins = "GPIO202/SMB0CSDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio202o_pins: gpio202o-pins {
+			pins = "GPIO202/SMB0CSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio202od_pins: gpio202od-pins {
+			pins = "GPIO202/SMB0CSDA";
+			bias-disable;
+			drive-open-drain;
+		};
+		gpio203_pins: gpio203-pins {
+			pins = "GPIO203/FANIN16";
+			bias-disable;
+			input-enable;
+		};
+		gpio203o_pins: gpio203o-pins {
+			pins = "GPIO203/FANIN16";
+			bias-disable;
+			output-high;
+		};
+		gpio203ol_pins: gpio203ol-pins {
+			pins = "GPIO203/FANIN16";
+			bias-disable;
+			output-low;
+		};
+		gpio204_pins: gpio204-pins {
+			pins = "GPIO204/DDC2SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio204o_pins: gpio204o-pins {
+			pins = "GPIO204/DDC2SCL";
+			bias-disable;
+			output-high;
+		};
+		gpio204ol_pins: gpio204ol-pins {
+			pins = "GPIO204/DDC2SCL";
+			bias-disable;
+			output-low;
+		};
+		gpio205_pins: gpio205-pins {
+			pins = "GPIO205/DDC2SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio205o_pins: gpio205o-pins {
+			pins = "GPIO205/DDC2SDA";
+			bias-disable;
+			output-high;
+		};
+		gpio205ol_pins: gpio205ol-pins {
+			pins = "GPIO205/DDC2SDA";
+			bias-disable;
+			output-low;
+		};
+		gpio206_pins: gpio206-pins {
+			pins = "GPIO206/HSYNC2";
+			bias-disable;
+			input-enable;
+		};
+		gpio206o_pins: gpio206o-pins {
+			pins = "GPIO206/HSYNC2";
+			bias-disable;
+			output-high;
+		};
+		gpio206ol_pins: gpio206ol-pins {
+			pins = "GPIO206/HSYNC2";
+			bias-disable;
+			output-low;
+		};
+		gpio207_pins: gpio207-pins {
+			pins = "GPIO207/VSYNC2";
+			bias-disable;
+			input-enable;
+		};
+		gpio207o_pins: gpio207o-pins {
+			pins = "GPIO207/VSYNC2";
+			bias-disable;
+			output-high;
+		};
+		gpio207ol_pins: gpio207ol-pins {
+			pins = "GPIO207/VSYNC2";
+			bias-disable;
+			output-low;
+		};
+		gpio208_pins: gpio208-pins {
+			pins = "GPIO208/RG2TXC/DVCK";
+			bias-disable;
+			input-enable;
+		};
+		gpio208o_pins: gpio208o-pins {
+			pins = "GPIO208/RG2TXC/DVCK";
+			bias-disable;
+			output-high;
+		};
+		gpio208ol_pins: gpio208ol-pins {
+			pins = "GPIO208/RG2TXC/DVCK";
+			bias-disable;
+			output-low;
+		};
+		gpio209_pins: gpio209-pins {
+			pins = "GPIO209/RG2TXCTL/DDRV4";
+			bias-disable;
+			input-enable;
+		};
+		gpio209ol_pins: gpio209ol-pins {
+			pins = "GPIO209/RG2TXCTL/DDRV4";
+			bias-disable;
+			output-low;
+		};
+		gpio210_pins: gpio210-pins {
+			pins = "GPIO210/RG2RXD0/DDRV5";
+			bias-disable;
+			input-enable;
+		};
+		gpio210o_pins: gpio210o-pins {
+			pins = "GPIO210/RG2RXD0/DDRV5";
+			bias-disable;
+			output-high;
+		};
+		gpio210ol_pins: gpio210ol-pins {
+			pins = "GPIO210/RG2RXD0/DDRV5";
+			bias-disable;
+			output-low;
+		};
+		gpio211_pins: gpio211-pins {
+			pins = "GPIO211/RG2RXD1/DDRV6";
+			bias-disable;
+			input-enable;
+		};
+		gpio211o_pins: gpio211o-pins {
+			pins = "GPIO211/RG2RXD1/DDRV6";
+			bias-disable;
+			output-high;
+		};
+		gpio211ol_pins: gpio211ol-pins {
+			pins = "GPIO211/RG2RXD1/DDRV6";
+			bias-disable;
+			output-low;
+		};
+		gpio212_pins: gpio212-pins {
+			pins = "GPIO212/RG2RXD2/DDRV7";
+			bias-disable;
+			input-enable;
+		};
+		gpio212o_pins: gpio212o-pins {
+			pins = "GPIO212/RG2RXD2/DDRV7";
+			bias-disable;
+			output-high;
+		};
+		gpio212ol_pins: gpio212ol-pins {
+			pins = "GPIO212/RG2RXD2/DDRV7";
+			bias-disable;
+			output-low;
+		};
+		gpio213_pins: gpio213-pins {
+			pins = "GPIO213/RG2RXD3/DDRV8";
+			bias-disable;
+			input-enable;
+		};
+		gpio213o_pins: gpio213o-pins {
+			pins = "GPIO213/RG2RXD3/DDRV8";
+			bias-disable;
+			output-high;
+		};
+		gpio213ol_pins: gpio213ol-pins {
+			pins = "GPIO213/RG2RXD3/DDRV8";
+			bias-disable;
+			output-low;
+		};
+		gpio214_pins: gpio214-pins {
+			pins = "GPIO214/RG2RXC/DDRV9";
+			bias-disable;
+			input-enable;
+		};
+		gpio214ol_pins: gpio214ol-pins {
+			pins = "GPIO214/RG2RXC/DDRV9";
+			bias-disable;
+			output-low;
+		};
+		gpio215_pins: gpio215-pins {
+			pins = "GPIO215/RG2RXCTL/DDRV10";
+			bias-disable;
+			input-enable;
+		};
+		gpio215ol_pins: gpio215ol-pins {
+			pins = "GPIO215/RG2RXCTL/DDRV10";
+			bias-disable;
+			output-low;
+		};
+		gpio216_pins: gpio216-pins {
+			pins = "GPIO216/RG2MDC/DDRV11";
+			bias-disable;
+			input-enable;
+		};
+		gpio216ol_pins: gpio216ol-pins {
+			pins = "GPIO216/RG2MDC/DDRV11";
+			bias-disable;
+			output-low;
+		};
+		gpio217_pins: gpio217-pins {
+			pins = "GPIO217/RG2MDIO/DVHSYNC";
+			bias-disable;
+			input-enable;
+		};
+		gpio217ol_pins: gpio217ol-pins {
+			pins = "GPIO217/RG2MDIO/DVHSYNC";
+			bias-disable;
+			output-low;
+		};
+		gpio218_pins: gpio218-pins {
+			pins = "GPIO218/nWDO1";
+			bias-disable;
+			input-enable;
+		};
+		gpio218ol_pins: gpio218ol-pins {
+			pins = "GPIO218/nWDO1";
+			bias-disable;
+			output-low;
+		};
+		gpio219_pins: gpio219-pins {
+			pins = "GPIO219/nWDO2";
+			bias-disable;
+			input-enable;
+		};
+		gpio219ol_pins: gpio219ol-pins {
+			pins = "GPIO219/nWDO2";
+			bias-disable;
+			output-low;
+		};
+		gpio220ol_pins: gpio220ol-pins {
+			pins = "GPIO220/SMB12SCL";
+			bias-disable;
+			output-low;
+		};
+		gpio221o_pins: gpio221o-pins {
+			pins = "GPIO221/SMB12SDA";
+			bias-disable;
+			output-high;
+		};
+		gpio222_pins: gpio222-pins {
+			pins = "GPIO222/SMB13SCL";
+			bias-disable;
+			input-enable;
+		};
+		gpio222o_pins: gpio222o-pins {
+			pins = "GPIO222/SMB13SCL";
+			bias-disable;
+			output-high;
+		};
+		gpio223_pins: gpio223-pins {
+			pins = "GPIO223/SMB13SDA";
+			bias-disable;
+			input-enable;
+		};
+		gpio223ol_pins: gpio223ol-pins {
+			pins = "GPIO223/SMB13SDA";
+			bias-disable;
+			output-low;
+		};
+		gpio224_pins: gpio224-pins {
+			pins = "GPIO224/SPIXCK";
+			bias-disable;
+			input-enable;
+		};
+		gpio224o_pins: gpio224o-pins {
+			pins = "GPIO224/SPIXCK";
+			bias-disable;
+			output-high;
+		};
+		gpio224ol_pins: gpio224ol-pins {
+			pins = "GPIO224/SPIXCK";
+			bias-disable;
+			output-low;
+		};
+		gpio225_pins: gpio225-pins {
+			pins = "GPO225/SPIXD0/STRAP12";
+			bias-disable;
+			input-enable;
+		};
+		gpio225o_pins: gpio225o-pins {
+			pins = "GPO225/SPIXD0/STRAP12";
+			bias-disable;
+			output-high;
+		};
+		gpio226_pins: gpio226-pins {
+			pins = "GPO226/SPIXD1/STRAP13";
+			bias-disable;
+			input-enable;
+		};
+		gpio226o_pins: gpio226o-pins {
+			pins = "GPO226/SPIXD1/STRAP13";
+			bias-disable;
+			output-high;
+		};
+		gpio227_pins: gpio227-pins {
+			pins = "GPIO227/nSPIXCS0";
+			bias-disable;
+			input-enable;
+		};
+		gpio227o_pins: gpio227o-pins {
+			pins = "GPIO227/nSPIXCS0";
+			bias-disable;
+			output-high;
+		};
+		gpio227ol_pins: gpio227ol-pins {
+			pins = "GPIO227/nSPIXCS0";
+			bias-disable;
+			output-low;
+		};
+		gpio228_pins: gpio228-pins {
+			pins = "GPIO228/nSPIXCS1";
+			bias-disable;
+			input-enable;
+		};
+		gpio228ol_pins: gpio228ol-pins {
+			pins = "GPIO228/nSPIXCS1";
+			bias-disable;
+			output-low;
+		};
+		gpio229_pins: gpio229-pins {
+			pins = "GPO229/SPIXD2/STRAP3";
+			bias-disable;
+			input-enable;
+		};
+		gpio229o_pins: gpio229o-pins {
+			pins = "GPO229/SPIXD2/STRAP3";
+			bias-disable;
+			output-high;
+		};
+		gpio230_pins: gpio230-pins {
+			pins = "GPIO230/SPIXD3";
+			bias-disable;
+			input-enable;
+		};
+		gpio230o_pins: gpio230o-pins {
+			pins = "GPIO230/SPIXD3";
+			bias-disable;
+			output-high;
+		};
+		gpio230ol_pins: gpio230ol-pins {
+			pins = "GPIO230/SPIXD3";
+			bias-disable;
+			output-low;
+		};
+		gpio231_pins: gpio231-pins {
+			pins = "GPIO231/nCLKREQ";
+			bias-disable;
+			input-enable;
+		};
+		gpio231o_pins: gpio231o-pins {
+			pins = "GPIO231/nCLKREQ";
+			bias-disable;
+			output-high;
+		};
+		gpio255_pins: gpio255-pins {
+			pins = "GPI255/DACOSEL";
+			bias-disable;
+			input-enable;
+		};
+	};
+};

--- a/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
@@ -5,7 +5,7 @@
 #include "nuvoton-npcm730.dtsi"
 #include "nuvoton-npcm730-gsj-gpio.dtsi"
 / {
-	model = "Quanta GSJ Board (Device Tree v7))";
+	model = "Quanta GSJ Board (Device Tree v7)";
 	compatible = "nuvoton,npcm750";
 
 	aliases {
@@ -47,7 +47,7 @@
 		};
 
 		mc: memory-controller@f0824000 {
-			compatible = "nuvton,ECC";
+			compatible = "nuvoton,npcm7xx-sdram-edac";
 			reg = <0xf0824000 0x1000>;
 			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
 		};

--- a/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
@@ -1,0 +1,602 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2019 Quanta Computer lnc. Fran.Hsu@quantatw.com
+
+/dts-v1/;
+#include "nuvoton-npcm730.dtsi"
+#include "nuvoton-npcm730-gsj-gpio.dtsi"
+/ {
+	model = "Quanta GSJ Board (Device Tree v7))";
+	compatible = "nuvoton,npcm750";
+
+	aliases {
+		ethernet0 = &emc0;
+		ethernet1 = &gmac0;
+		serial3 = &serial3;
+		udc9 = &udc9;
+		i2c0 = &i2c0;
+		i2c1 = &i2c1;
+		i2c2 = &i2c2;
+		i2c3 = &i2c3;
+		i2c4 = &i2c4;
+		i2c5 = &i2c5;
+		i2c6 = &i2c6;
+		i2c7 = &i2c7;
+		i2c8 = &i2c8;
+		i2c9 = &i2c9;
+		i2c10 = &i2c10;
+		i2c11 = &i2c11;
+		i2c12 = &i2c12;
+		i2c13 = &i2c13;
+		i2c14 = &i2c14;
+		i2c15 = &i2c15;
+		fiu0 = &fiu0;
+	};
+
+	chosen {
+		stdout-path = &serial3;
+	};
+
+	memory {
+		reg = <0 0x40000000>;
+	};
+
+	ahb {
+		gmac0: eth@f0802000 {
+			phy-mode = "rgmii-id";
+			status = "okay";
+		};
+
+		mc: memory-controller@f0824000 {
+			compatible = "nuvton,ECC";
+			reg = <0xf0824000 0x1000>;
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
+		};
+
+		emc0: eth@f0825000 {
+			phy-mode = "rmii";
+			use-ncsi;
+			status = "okay";
+		};
+
+		ehci1: usb@f0806000 {
+			status = "okay";
+		};
+
+		ohci1: ohci@f0807000 {
+			status = "okay";
+		};
+
+		udc9:udc@f0839000 {
+			status = "okay";
+		};
+
+		aes:aes@f0858000 {
+			status = "okay";
+		};
+
+		sha:sha@f085a000 {
+			status = "okay";
+		};
+
+		fiu0: fiu@fb000000 {
+			pinctrl-names = "default";
+			pinctrl-0 = <&spi0cs1_pins>;
+			status = "okay";
+			spi-nor@0 {
+				compatible = "jedec,spi-nor";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				reg = <0>;
+				spi-rx-bus-width = <2>;
+				partitions@80000000 {
+						compatible = "fixed-partitions";
+						#address-cells = <1>;
+						#size-cells = <1>;
+						u-boot@0 {
+							label = "u-boot";
+							reg = <0x0000000 0x80000>;
+							read-only;
+						};
+						u-boot-env@100000{
+							label = "u-boot-env";
+							reg = <0x00100000 0x40000>;
+						};
+						kernel@200000 {
+							label = "kernel";
+							reg = <0x0200000 0x600000>;
+						};
+						rofs@800000 {
+							label = "rofs";
+							reg = <0x800000 0x1400000>;
+						};
+						rwfs@1c00000 {
+							label = "rwfs";
+							reg = <0x1c00000 0x300000>;
+						};
+						haven-update@1f00000 {
+							label = "haven-update";
+							reg = <0x1f00000 0x100000>;
+						};
+				};
+			};
+		};
+
+		pcimbox: pcimbox@f0848000 {
+			status = "okay";
+		};
+
+		apb {
+
+			watchdog1: watchdog@901C {
+				status = "okay";
+			};
+
+			rng: rng@b000 {
+				status = "okay";
+			};
+
+			serial0: serial@1000 {
+				status = "okay";
+			};
+
+			serial1: serial@2000 {
+				status = "okay";
+			};
+
+			serial2: serial@3000 {
+				status = "okay";
+			};
+
+			serial3: serial@4000 {
+				status = "okay";
+			};
+
+			adc: adc@c000 {
+				status = "okay";
+			};
+			otp:otp@189000 {
+				status = "okay";
+			};
+
+			i2c0: i2c@80000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "disabled";
+			};
+
+			i2c1: i2c@81000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+				lm75@5c {
+					compatible = "maxim,max31725";
+					reg = <0x5c>;
+					status = "okay";
+				};
+			};
+
+			i2c2: i2c@82000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+				lm75@5c {
+					compatible = "maxim,max31725";
+					reg = <0x5c>;
+					status = "okay";
+				};
+			};
+
+			i2c3: i2c@83000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+				lm75@5c {
+					compatible = "maxim,max31725";
+					reg = <0x5c>;
+					status = "okay";
+				};
+			};
+
+			i2c4: i2c@84000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+				lm75@5c {
+					compatible = "maxim,max31725";
+					reg = <0x5c>;
+					status = "okay";
+				};
+			};
+			i2c5: i2c@85000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "disabled";
+			};
+			i2c6: i2c@86000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "disabled";
+			};
+
+			i2c7: i2c@87000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "disabled";
+			};
+
+			i2c8: i2c@88000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+			};
+
+			i2c9: i2c@89000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+				eeprom@55 {
+					compatible = "atmel,24c64";
+					reg = <0x55>;
+				};
+			};
+
+			i2c10: i2c@8a000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+				eeprom@55 {
+					compatible = "atmel,24c64";
+					reg = <0x55>;
+				};
+			};
+
+			i2c11: i2c@8b000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+
+				/* P12V Quarter Brick DC/DC Power Module Q54SH12050 @60 */
+				power-brick@36 {
+					compatible = "delta,dps800";
+					reg = <0x36>;
+				};
+
+				hotswap@15 {
+					compatible = "ti,lm5066i";
+					reg = <0x15>;
+				};
+			};
+
+			i2c12: i2c@8c000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+			};
+
+			i2c13: i2c@8d000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+
+				ipmb@10 {
+					compatible = "slave-mqueue";
+					reg = <0x10>;
+					status = "okay";
+				};
+			};
+
+			i2c14: i2c@8e000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+
+				ipmb@12 {
+					compatible = "slave-mqueue";
+					reg = <0x12>;
+					status = "okay";
+				};
+			};
+
+			i2c15: i2c@8f000 {
+				#address-cells = <1>;
+				#size-cells = <0>;
+				bus-frequency = <100000>;
+				status = "okay";
+
+				i2c-switch@75 {
+					compatible = "nxp,pca9548";
+					#address-cells = <1>;
+					#size-cells = <0>;
+					reg = <0x75>;
+					i2c-mux-idle-disconnect;
+
+					i2c_u20: i2c@0 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <0>;
+					};
+
+					i2c_u21: i2c@1 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <1>;
+					};
+
+					i2c_u22: i2c@2 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <2>;
+					};
+
+					i2c_u23: i2c@3 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <3>;
+					};
+
+					i2c_u24: i2c@4 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <4>;
+					};
+
+					i2c_u25: i2c@5 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <5>;
+					};
+
+					i2c_u26: i2c@6 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <6>;
+					};
+
+					i2c_u27: i2c@7 {
+						#address-cells = <1>;
+						#size-cells = <0>;
+						reg = <7>;
+					};
+				};
+			};
+
+			pwm_fan:pwm-fan-controller@103000 {
+				pinctrl-names = "default";
+				pinctrl-0 = <&pwm0_pins &pwm1_pins &pwm2_pins
+						&fanin0_pins &fanin1_pins
+						&fanin2_pins &fanin3_pins
+						&fanin4_pins &fanin5_pins>;
+				status = "okay";
+				fan@0 {
+					reg = <0x00>;
+					fan-tach-ch = /bits/ 8 <0x00 0x01>;
+					cooling-levels = <127 255>;
+				};
+				fan@1 {
+					reg = <0x01>;
+					fan-tach-ch = /bits/ 8 <0x02 0x03>;
+					cooling-levels = /bits/ 8 <127 255>;
+				};
+				fan@2 {
+					reg = <0x02>;
+					fan-tach-ch = /bits/ 8 <0x04 0x05>;
+					cooling-levels = /bits/ 8 <127 255>;
+				};
+			};
+
+		};
+	};
+
+	pinctrl: pinctrl@f0800000 {
+		pinctrl-names = "default";
+		pinctrl-0 = <
+				/* GPI pins*/
+				&gpio8_pins
+				&gpio9_pins
+				&gpio12_pins
+				&gpio13_pins
+				&gpio14_pins
+				&gpio60_pins
+				&gpio83_pins
+				&gpio91_pins
+				&gpio92_pins
+				&gpio95_pins
+				&gpio136_pins
+				&gpio137_pins
+				&gpio141_pins
+				&gpio144_pins
+				&gpio145_pins
+				&gpio146_pins
+				&gpio147_pins
+				&gpio148_pins
+				&gpio149_pins
+				&gpio150_pins
+				&gpio151_pins
+				&gpio152_pins
+				&gpio153_pins
+				&gpio154_pins
+				&gpio155_pins
+				&gpio156_pins
+				&gpio157_pins
+				&gpio158_pins
+				&gpio159_pins
+				&gpio161_pins
+				&gpio162_pins
+				&gpio163_pins
+				&gpio164_pins
+				&gpio165_pins
+				&gpio166_pins
+				&gpio167_pins
+				&gpio168_pins
+				&gpio169_pins
+				&gpio170_pins
+				&gpio177_pins
+				&gpio191_pins
+				&gpio192_pins
+				&gpio203_pins
+				/* GPO pins*/
+				&gpio0pp_pins
+				&gpio1pp_pins
+				&gpio2pp_pins
+				&gpio3pp_pins
+				&gpio4pp_pins
+				&gpio5pp_pins
+				&gpio6pp_pins
+				&gpio7pp_pins
+				&gpio10pp_pins
+				&gpio11pp_pins
+				&gpio15od_pins
+				&gpio17pp_pins
+				&gpio18pp_pins
+				&gpio19pp_pins
+				&gpio24pp_pins
+				&gpio25pp_pins
+				&gpio37od_pins
+				&gpio59pp_pins
+				&gpio72od_pins
+				&gpio73od_pins
+				&gpio74od_pins
+				&gpio75od_pins
+				&gpio76od_pins
+				&gpio77od_pins
+				&gpio78od_pins
+				&gpio79od_pins
+				&gpio84pp_pins
+				&gpio85pp_pins
+				&gpio86pp_pins
+				&gpio87pp_pins
+				&gpio88pp_pins
+				&gpio89pp_pins
+				&gpio90pp_pins
+				&gpio93pp_pins
+				&gpio94pp_pins
+				&gpio125pp_pins
+				&gpio126od_pins
+				&gpio127od_pins
+				&gpio142od_pins
+				&gpio143ol_pins
+				&gpio175od_pins
+				&gpio176od_pins
+				&gpio190od_pins
+				&gpio194pp_pins
+				&gpio195od_pins
+				&gpio196od_pins
+				&gpio197od_pins
+				&gpio198od_pins
+				&gpio199od_pins
+				&gpio200pp_pins
+				&gpio202od_pins
+				>;
+	};
+
+
+
+	leds {
+		compatible = "gpio-leds";
+
+		led-bmc-live {
+			gpios = <&gpio4 15 GPIO_ACTIVE_HIGH>;
+			linux,default-trigger = "heartbeat";
+		};
+
+		LED_U2_0_LOCATE {
+			gpios = <&gpio0 0 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_1_LOCATE {
+			gpios = <&gpio0 1 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_2_LOCATE {
+			gpios = <&gpio0 2 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_3_LOCATE {
+			gpios = <&gpio0 3 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_4_LOCATE {
+			gpios = <&gpio0 10 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_5_LOCATE {
+			gpios = <&gpio0 11 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_BMC_TRAY_PWRGD {
+			gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_7_FAULT {
+			gpios = <&gpio6 8 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_6_LOCATE {
+			gpios = <&gpio0 24 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_7_LOCATE {
+			gpios = <&gpio0 25 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_0_FAULT {
+			gpios = <&gpio2 20 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_1_FAULT {
+			gpios = <&gpio2 21 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_2_FAULT {
+			gpios = <&gpio2 22 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_3_FAULT {
+			gpios = <&gpio2 23 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_4_FAULT {
+			gpios = <&gpio2 24 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_5_FAULT {
+			gpios = <&gpio2 25 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+
+		LED_U2_6_FAULT {
+			gpios = <&gpio2 26 GPIO_ACTIVE_HIGH>;
+			default-state = "off";
+		};
+	};
+};

--- a/drivers/edac/Kconfig
+++ b/drivers/edac/Kconfig
@@ -460,4 +460,11 @@ config EDAC_TI
 	  Support for error detection and correction on the
           TI SoCs.
 
+config EDAC_NPCM7XX
+        tristate "Nuvoton NPCM7xx DDR Memory Controller"
+        depends on ARCH_NPCM7XX
+        help
+          Support for error detection and correction on the
+          Nuvoton NPCM7xx DDR memory controller.
+
 endif # EDAC

--- a/drivers/edac/Makefile
+++ b/drivers/edac/Makefile
@@ -77,3 +77,5 @@ obj-$(CONFIG_EDAC_ALTERA)		+= altera_edac.o
 obj-$(CONFIG_EDAC_SYNOPSYS)		+= synopsys_edac.o
 obj-$(CONFIG_EDAC_XGENE)		+= xgene_edac.o
 obj-$(CONFIG_EDAC_TI)			+= ti_edac.o
+
+obj-$(CONFIG_EDAC_NPCM7XX)		+= npcm7xx_edac.o

--- a/drivers/edac/npcm7xx_edac.c
+++ b/drivers/edac/npcm7xx_edac.c
@@ -1,0 +1,424 @@
+// SPDX-License-Identifier: GPL-2.0
+/*
+ * Copyright (c) 2019 Quanta Computer lnc.
+ */
+
+#include <linux/edac.h>
+#include <linux/interrupt.h>
+#include <linux/module.h>
+#include <linux/platform_device.h>
+#include <linux/of_address.h>
+#include <linux/of_device.h>
+
+#include "edac_module.h"
+
+#define ECC_ENABLE                     BIT(24)
+#define ECC_EN_INT_MASK                0x7fffff87
+
+#define INT_STATUS_ADDR                116
+#define INT_ACK_ADDR                   117
+#define INT_MASK_ADDR                  118
+
+#define ECC_EN_ADDR                    93
+#define ECC_C_ADDR_ADDR                98
+#define ECC_C_DATA_ADDR                100
+#define ECC_C_ID_ADDR                  101
+#define ECC_C_SYND_ADDR                99
+#define ECC_U_ADDR_ADDR                95
+#define ECC_U_DATA_ADDR                97
+#define ECC_U_ID_ADDR                  101
+#define ECC_U_SYND_ADDR                96
+
+#define ECC_ERROR                      -1
+#define EDAC_MSG_SIZE                  256
+#define EDAC_MOD_NAME                  "npcm7xx-edac"
+
+struct ecc_error_signature_info {
+	u32 ecc_addr;
+	u32 ecc_data;
+	u32 ecc_id;
+	u32 ecc_synd;
+};
+
+struct npcm7xx_ecc_int_status {
+	u32 int_mask;
+	u32 int_status;
+	u32 int_ack;
+	u32 ce_cnt;
+	u32 ue_cnt;
+	struct ecc_error_signature_info ceinfo;
+	struct ecc_error_signature_info ueinfo;
+};
+
+struct npcm7xx_edac_priv {
+	void __iomem *baseaddr;
+	char message[EDAC_MSG_SIZE];
+	struct npcm7xx_ecc_int_status stat;
+};
+
+/**
+ * npcm7xx_edac_get_ecc_syndrom - Get the current ecc error info
+ * @base:	Pointer to the base address of the ddr memory controller
+ * @p:		Pointer to the Nuvoton ecc status structure
+ *
+ * Determines there is any ecc error or not
+ *
+ * Return: ECC detection status
+ */
+static int npcm7xx_edac_get_ecc_syndrom(void __iomem *base,
+					struct npcm7xx_ecc_int_status *p)
+{
+	int status = 0;
+	u32 int_status = 0;
+
+	int_status = readl(base + 4*INT_STATUS_ADDR);
+	writel(int_status, base + 4*INT_ACK_ADDR);
+	edac_dbg(3, "int_status: %#08x\n", int_status);
+
+	if ((int_status & (1 << 6)) == (1 << 6)) {
+		edac_dbg(3, "6-Mult uncorrectable detected.\n");
+		p->ue_cnt++;
+		status = ECC_ERROR;
+	}
+
+	if ((int_status & (1 << 5)) == (1 << 5)) {
+		edac_dbg(3, "5-An uncorrectable detected\n");
+		p->ue_cnt++;
+		status = ECC_ERROR;
+	}
+
+	if ((int_status & (1 << 4)) == (1 << 4)) {
+		edac_dbg(3, "4-mult correctable detected.\n");
+		p->ce_cnt++;
+		status = ECC_ERROR;
+	}
+
+	if ((int_status & (1 << 3)) == (1 << 3)) {
+		edac_dbg(3, "3-A correctable detected.\n");
+		p->ce_cnt++;
+		status = ECC_ERROR;
+	}
+
+	if (status == ECC_ERROR) {
+		u32 ecc_id;
+
+		p->ceinfo.ecc_addr = readl(base + 4*ECC_C_ADDR_ADDR);
+		p->ceinfo.ecc_data = readl(base + 4*ECC_C_DATA_ADDR);
+		p->ceinfo.ecc_synd = readl(base + 4*ECC_C_SYND_ADDR);
+
+		p->ueinfo.ecc_addr = readl(base + 4*ECC_U_ADDR_ADDR);
+		p->ueinfo.ecc_data = readl(base + 4*ECC_U_DATA_ADDR);
+		p->ueinfo.ecc_synd = readl(base + 4*ECC_U_SYND_ADDR);
+
+		/* ECC_C_ID_ADDR has same value as ECC_U_ID_ADDR */
+		ecc_id = readl(base + 4*ECC_C_ID_ADDR);
+		p->ueinfo.ecc_id = ecc_id & 0xffff;
+		p->ceinfo.ecc_id = ecc_id >> 16;
+	}
+
+	return status;
+}
+
+/**
+ * npcm7xx_edac_handle_error - Handle controller error types CE and UE
+ * @mci:	Pointer to the edac memory controller instance
+ * @p:		Pointer to the Nuvoton ecc status structure
+ *
+ * Handles the controller ECC correctable and un correctable error.
+ */
+static void npcm7xx_edac_handle_error(struct mem_ctl_info *mci,
+				    struct npcm7xx_ecc_int_status *p)
+{
+	struct npcm7xx_edac_priv *priv = mci->pvt_info;
+	u32 page, offset;
+
+	if (p->ce_cnt) {
+		snprintf(priv->message, EDAC_MSG_SIZE,
+			"DDR ECC: synd=%#08x addr=%#08x data=%#08x source_id=%#08x ",
+			p->ceinfo.ecc_synd, p->ceinfo.ecc_addr,
+			p->ceinfo.ecc_data, p->ceinfo.ecc_id);
+
+		page = p->ceinfo.ecc_addr >> PAGE_SHIFT;
+		offset = p->ceinfo.ecc_addr & ~PAGE_MASK;
+		edac_mc_handle_error(HW_EVENT_ERR_CORRECTED, mci,
+				     p->ce_cnt, page, offset,
+				     p->ceinfo.ecc_synd,
+				     0, 0, -1,
+				     priv->message, "");
+	}
+
+	if (p->ue_cnt) {
+		snprintf(priv->message, EDAC_MSG_SIZE,
+			"DDR ECC: synd=%#08x addr=%#08x data=%#08x source_id=%#08x ",
+			p->ueinfo.ecc_synd, p->ueinfo.ecc_addr,
+			p->ueinfo.ecc_data, p->ueinfo.ecc_id);
+
+		page = p->ueinfo.ecc_addr >> PAGE_SHIFT;
+		offset = p->ueinfo.ecc_addr & ~PAGE_MASK;
+		edac_mc_handle_error(HW_EVENT_ERR_UNCORRECTED, mci,
+				     p->ue_cnt, page, offset,
+				     p->ueinfo.ecc_synd,
+				     0, 0, -1,
+				     priv->message, "");
+	}
+
+	memset(p, 0, sizeof(*p));
+}
+
+/**
+ * npcm7xx_edac_check - Check controller for ECC errors
+ * @mci:	Pointer to the edac memory controller instance
+ *
+ * This routine is used to check and post ECC errors and is called by
+ * this driver's CE and UE interrupt handler.
+ */
+static void npcm7xx_edac_check(struct mem_ctl_info *mci)
+{
+	struct npcm7xx_edac_priv *priv = mci->pvt_info;
+	int status = 0;
+
+	status = npcm7xx_edac_get_ecc_syndrom(priv->baseaddr, &priv->stat);
+	if (status != ECC_ERROR)
+		return;
+
+	npcm7xx_edac_handle_error(mci, &priv->stat);
+}
+
+/**
+ * npcm7xx_edac_isr - CE/UE interrupt service routine
+ * @irq:    The virtual interrupt number being serviced.
+ * @dev_id: A pointer to the EDAC memory controller instance
+ *          associated with the interrupt being handled.
+ *
+ * This routine implements the interrupt handler for both correctable
+ * (CE) and uncorrectable (UE) ECC errors for the Nuvoton Cadence DDR
+ * controller. It simply calls through to the routine used to check,
+ * report and clear the ECC status.
+ *
+ * Unconditionally returns IRQ_HANDLED.
+ */
+static irqreturn_t npcm7xx_edac_isr(int irq, void *dev_id)
+{
+	struct mem_ctl_info *mci = dev_id;
+	int npcm_edac_report = 0;
+
+	npcm_edac_report = edac_get_report_status();
+	if (npcm_edac_report != EDAC_REPORTING_DISABLED)
+		npcm7xx_edac_check(mci);
+
+	return IRQ_HANDLED;
+}
+
+static int npcm7xx_edac_register_irq(struct mem_ctl_info *mci,
+					struct platform_device *pdev)
+{
+	int status = 0;
+	int mc_irq;
+	struct npcm7xx_edac_priv *priv = mci->pvt_info;
+
+	mc_irq = platform_get_irq(pdev, 0);
+
+	if (!mc_irq) {
+		edac_printk(KERN_ERR, EDAC_MC, "Unable to map interrupts.\n");
+		status = -ENODEV;
+		goto fail;
+	}
+
+	status = devm_request_irq(&pdev->dev, mc_irq, npcm7xx_edac_isr, 0,
+			       "npcm-memory-controller", mci);
+
+	if (status < 0) {
+		edac_printk(KERN_ERR, EDAC_MC,
+				      "Unable to request irq %d for ECC",
+				      mc_irq);
+		status = -ENODEV;
+		goto fail;
+	}
+
+	/* Only enable MC interrupts with ECC - clear int_mask[6:3] */
+	writel(ECC_EN_INT_MASK, priv->baseaddr + 4*INT_MASK_ADDR);
+
+	return 0;
+
+fail:
+	return status;
+}
+
+static const struct of_device_id npcm7xx_edac_of_match[] = {
+	{ .compatible = "nuvoton,npcm7xx-sdram-edac"},
+	{ /* end of table */ }
+};
+
+MODULE_DEVICE_TABLE(of, npcm7xx_edac_of_match);
+
+/**
+ * npcm7xx_edac_mc_init - Initialize driver instance
+ * @mci:	Pointer to the edac memory controller instance
+ * @pdev:	Pointer to the platform_device struct
+ *
+ * Performs initialization of the EDAC memory controller instance and
+ * related driver-private data associated with the memory controller the
+ * instance is bound to.
+ *
+ * Returns 0 if OK; otherwise, < 0 on error.
+ */
+static int npcm7xx_edac_mc_init(struct mem_ctl_info *mci,
+				 struct platform_device *pdev)
+{
+	const struct of_device_id *id;
+
+	id = of_match_device(npcm7xx_edac_of_match, &pdev->dev);
+	if (!id)
+		return -ENODEV;
+
+	/* Initialize controller capabilities and configuration */
+	mci->mtype_cap = MEM_FLAG_DDR4;
+	mci->edac_ctl_cap = EDAC_FLAG_SECDED;
+	mci->edac_cap = EDAC_FLAG_SECDED;
+	mci->scrub_cap = SCRUB_FLAG_HW_SRC;
+	mci->scrub_mode = SCRUB_HW_SRC;
+	mci->ctl_name = id->compatible;
+	mci->dev_name = dev_name(&pdev->dev);
+	mci->mod_name = EDAC_MOD_NAME;
+
+	edac_op_state = EDAC_OPSTATE_INT;
+
+	return 0;
+}
+
+/**
+ * npcm7xx_edac_get_eccstate - Return the controller ecc enable/disable status
+ * @base:	Pointer to the ddr memory controller base address
+ *
+ * Get the ECC enable/disable status for the controller
+ *
+ * Return: a ecc status boolean i.e true/false - enabled/disabled.
+ */
+static bool npcm7xx_edac_get_eccstate(void __iomem *base)
+{
+	u32 ecc_en;
+	bool state = false;
+
+	ecc_en = readl(base + 4*ECC_EN_ADDR);
+	if (ecc_en & ECC_ENABLE) {
+		edac_printk(KERN_INFO, EDAC_MC, "ECC reporting and correcting on. ");
+		state = true;
+	}
+
+	return state;
+}
+
+/**
+ * npcm7xx_edac_mc_probe - Check controller and bind driver
+ * @pdev:	Pointer to the platform_device struct
+ *
+ * Probes a specific controller instance for binding with the driver.
+ *
+ * Return: 0 if the controller instance was successfully bound to the
+ * driver; otherwise, < 0 on error.
+ */
+static int npcm7xx_edac_mc_probe(struct platform_device *pdev)
+{
+	struct mem_ctl_info *mci;
+	struct edac_mc_layer layers[1];
+	struct npcm7xx_edac_priv *priv;
+	struct resource *res;
+	void __iomem *baseaddr;
+	int rc;
+
+	res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	baseaddr = devm_ioremap_resource(&pdev->dev, res);
+	if (IS_ERR(baseaddr)) {
+		edac_printk(KERN_ERR, EDAC_MOD_NAME,
+			    "DDR controller regs not defined\n");
+		return PTR_ERR(baseaddr);
+	}
+
+	/*
+	 * Check if ECC is enabled.
+	 * If not, there is no useful monitoring that can be done
+	 * for this controller.
+	 */
+	if (!npcm7xx_edac_get_eccstate(baseaddr)) {
+		edac_printk(KERN_INFO, EDAC_MC, "ECC disabled\n");
+		return -ENXIO;
+	}
+
+	/*
+	 * Allocate an EDA controller instance and perform the appropriate
+	 * initialization.
+	 */
+	layers[0].type = EDAC_MC_LAYER_ALL_MEM;
+	layers[0].size = 1;
+
+	mci = edac_mc_alloc(0, ARRAY_SIZE(layers), layers,
+			    sizeof(struct npcm7xx_edac_priv));
+	if (!mci) {
+		edac_printk(KERN_ERR, EDAC_MC,
+			    "Failed memory allocation for mc instance\n");
+		return -ENOMEM;
+	}
+
+	mci->pdev = &pdev->dev;
+	priv = mci->pvt_info;
+	priv->baseaddr = baseaddr;
+	platform_set_drvdata(pdev, mci);
+
+	rc = npcm7xx_edac_mc_init(mci, pdev);
+	if (rc) {
+		edac_printk(KERN_ERR, EDAC_MC,
+			    "Failed to initialize instance\n");
+		goto free_edac_mc;
+	}
+
+	/* Attempt to register it with the EDAC subsystem */
+	rc = edac_mc_add_mc(mci);
+	if (rc) {
+		edac_printk(KERN_ERR, EDAC_MC,
+			    "Failed to register with EDAC core\n");
+		goto free_edac_mc;
+	}
+
+	/* Register interrupts */
+	rc = npcm7xx_edac_register_irq(mci, pdev);
+	if (rc)
+		goto free_edac_mc;
+
+	return 0;
+
+free_edac_mc:
+	edac_mc_free(mci);
+
+	return rc;
+}
+
+/**
+ * npcm7xx_edac_mc_remove - Unbind driver from controller
+ * @pdev:	Pointer to the platform_device struct
+ *
+ * Return: Unconditionally 0
+ */
+static int npcm7xx_edac_mc_remove(struct platform_device *pdev)
+{
+	struct mem_ctl_info *mci = platform_get_drvdata(pdev);
+
+	edac_mc_del_mc(&pdev->dev);
+	edac_mc_free(mci);
+
+	return 0;
+}
+
+static struct platform_driver npcm7xx_edac_driver = {
+	.probe = npcm7xx_edac_mc_probe,
+	.remove = npcm7xx_edac_mc_remove,
+	.driver = {
+		   .name = EDAC_MOD_NAME,
+		   .of_match_table = npcm7xx_edac_of_match,
+	},
+};
+
+module_platform_driver(npcm7xx_edac_driver);
+
+MODULE_AUTHOR("Quanta Computer Inc.");
+MODULE_DESCRIPTION("Nuvoton NPCM7xx EDAC Driver");
+MODULE_LICENSE("GPL v2");


### PR DESCRIPTION
1.Commit GSJ kernel device tree v7.
2.Commir NPCM7xx EDAC driver and Kernel configuration/Documents.
Test on GSJ BMC module and it could boot to linux shell successfully.
Signed-off-by: FranHsu <Fran.Hsu@quantatw.com>