### PR TITLE
Poleg 4.19.16 open bmc

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
@@ -5,7 +5,7 @@
 #include "nuvoton-npcm730.dtsi"
 #include "nuvoton-npcm730-gsj-gpio.dtsi"
 / {
-	model = "Quanta GSJ Board (Device Tree v7))";
+	model = "Quanta GSJ Board (Device Tree v7)";
 	compatible = "nuvoton,npcm750";
 
 	aliases {
@@ -47,7 +47,7 @@
 		};
 
 		mc: memory-controller@f0824000 {
-			compatible = "nuvton,ECC";
+			compatible = "nuvoton,npcm7xx-sdram-edac";
 			reg = <0xf0824000 0x1000>;
 			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
 		};

--- a/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
@@ -5,7 +5,7 @@
 #include "nuvoton-npcm730.dtsi"
 #include "nuvoton-npcm730-gsj-gpio.dtsi"
 / {
-	model = "Quanta GSJ Board (Device Tree v7)";
+	model = "Quanta GSJ Board (Device Tree v7))";
 	compatible = "nuvoton,npcm750";
 
 	aliases {
@@ -47,7 +47,7 @@
 		};
 
 		mc: memory-controller@f0824000 {
-			compatible = "nuvoton,npcm7xx-sdram-edac";
+			compatible = "nuvton,ECC";
 			reg = <0xf0824000 0x1000>;
 			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
 		};


### PR DESCRIPTION
I have to update the name of mtd5 for the reason of compatible.