### PR TITLE
Change the name of mtd5

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
@@ -5,7 +5,7 @@
 #include "nuvoton-npcm730.dtsi"
 #include "nuvoton-npcm730-gsj-gpio.dtsi"
 / {
-	model = "Quanta GSJ Board (Device Tree v7)";
+	model = "Quanta GSJ Board (Device Tree v8)";
 	compatible = "nuvoton,npcm750";
 
 	aliases {
@@ -113,8 +113,8 @@
 							label = "rwfs";
 							reg = <0x1c00000 0x300000>;
 						};
-						haven-update@1f00000 {
-							label = "haven-update";
+						reserved@1f00000 {
+							label = "reserved";
 							reg = <0x1f00000 0x100000>;
 						};
 				};


### PR DESCRIPTION
I have to update the name of mtd5 for the reason of compatible.
Signed-off-by: FranHsu <Fran.Hsu@quantatw.com>