### PR TITLE
edac:npcm: fix ecc kernel panic issue

### DIFF
--- a/drivers/edac/npcm7xx_edac.c
+++ b/drivers/edac/npcm7xx_edac.c
@@ -216,6 +216,9 @@ static int npcm7xx_edac_register_irq(struct mem_ctl_info *mci,
 	int mc_irq;
 	struct npcm7xx_edac_priv *priv = mci->pvt_info;
 
+	/* Only enable MC interrupts with ECC - clear int_mask[6:3] */
+	writel(ECC_EN_INT_MASK, priv->baseaddr + 4*INT_MASK_ADDR);
+
 	mc_irq = platform_get_irq(pdev, 0);
 
 	if (!mc_irq) {
@@ -234,9 +237,6 @@ static int npcm7xx_edac_register_irq(struct mem_ctl_info *mci,
 		status = -ENODEV;
 		goto fail;
 	}
-
-	/* Only enable MC interrupts with ECC - clear int_mask[6:3] */
-	writel(ECC_EN_INT_MASK, priv->baseaddr + 4*INT_MASK_ADDR);
 
 	return 0;
 


### PR DESCRIPTION
Other memory interrupts except for ECC events may cause
RCU cpu stall lead to kernel panic. Need to Mask them
before registering irq

Signed-off-by: George Hung <george.hung@quantatw.com>