### PR TITLE
dts: nuvoton-npcm750-runbmc: add the delta dps800 dts node

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm750-runbmc.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-runbmc.dts
@@ -395,6 +395,11 @@
 					compatible = "ti,tmp421";
 					reg = <0x4c>;
 				};
+        /* P12V Quarter Brick DC/DC Power Module Q54SH12050 @58 */
+        power-brick@58 {
+          compatible = "delta,dps800";
+          reg = <0x58>;
+        };
 			};
 
 			i2c3: i2c@83000 {


### PR DESCRIPTION
1. Delta dps800 is supported by the generic linux pmbus driver.

Signed-off-by: kfting <kfting@nuvoton.com>