### PR TITLE
dts: nuvoton-npcm750-runbmc: add support for runbmc ipmb

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm750-runbmc.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-runbmc.dts
@@ -425,6 +425,11 @@
 				#size-cells = <0>;
 				bus-frequency = <100000>;
 				status = "okay";
+        slave_mqueue: i2c-slave-mqueue {
+          compatible = "i2c-slave-mqueue";
+          reg = <0x40000010>;
+          status = "okay";
+        };
 			};
 
 			i2c6: i2c@86000 {


### PR DESCRIPTION
1. i2c bus 5 is used as to communicate with ME on runbmc.

Signed-off-by: kfting <kfting@nuvoton.com>