### PR TITLE
dts: nuvoton-npcm730-gsj: add spi-max-frequency property to spi-nor node

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gsj.dts
@@ -78,6 +78,7 @@
 			status = "okay";
 			spi-nor@0 {
 				compatible = "jedec,spi-nor";
+				spi-max-frequency = <5000000>;
 				#address-cells = <1>;
 				#size-cells = <1>;
 				reg = <0>;


### PR DESCRIPTION
Without this, probing the flash chip fails with

spi_master spi0: /ahb/fiu@fb000000/spi-nor@0 has no valid 'spi-max-frequency' property (-22)
spi_master spi0: Failed to create SPI device for /ahb/fiu@fb000000/spi-nor@0

With this patch, the flash chip is probed correctly:

spi-nor spi0.0: mx25l25635e (32768 Kbytes)
7 fixed-partitions partitions found on MTD device spi0.0

Signed-off-by: Havard Skinnemoen <hskinnemoen@google.com>