### PR TITLE
dts: npcm750-runbmc: extend U-Boot size

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm750-runbmc-olympus.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-runbmc-olympus.dts
@@ -173,7 +173,7 @@
 					};
 					u-boot@0 {
 						label = "u-boot";
-						reg = <0x0000000 0x80000>;
+						reg = <0x0000000 0xC0000>;
 						read-only;
 					};
 					u-boot-env@100000{


### PR DESCRIPTION
Extend U-Boot size from 512K to 768K(0xC0000)

Signed-off-by: Brian Ma <chma0@nuvoton.com>