### PR TITLE
dts: npcm730-gbs: remove to include pincfg.dtsi

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
@@ -4,7 +4,6 @@
 
 /dts-v1/;
 #include "nuvoton-npcm730.dtsi"
-#include "nuvoton-npcm730-gbs-pincfg.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 
 / {


### PR DESCRIPTION
GPIOs are already initialized in u-boot pincfg.dtsi,
so remove to include the kernel pincfg.dtsi

Signed-off-by: George Hung <george.hung@quantatw.com>