### PR TITLE
dts: nuvoton-npcm750-runbmc-olympus: enable i2c slave mode on bus 2

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm750-runbmc-olympus.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-runbmc-olympus.dts
@@ -422,6 +422,11 @@
 					compatible = "pmbus";
 					reg = <0x58>;
 				};
+
+				slave_mqueue2: i2c-slave-mqueue@40000010 {
+					compatible = "i2c-slave-mqueue";
+					reg = <0x40000010>;
+				};
 			};
 
 			i2c3: i2c@83000 {


### PR DESCRIPTION
	note: slave address is 0x20

Signed-off-by: Medad CChien <ctcchien@nuvoton.com>