### PR TITLE
dts: npcm730-gbs: quanta gbs dts update

### DIFF
--- a/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
@@ -154,6 +154,13 @@
 			status = "disabled";
 		};
 
+		mc: memory-controller@f0824000 {
+			compatible = "nuvoton,npcm7xx-sdram-edac";
+			reg = <0xf0824000 0x1000>;
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+		};
+
 		emc0: eth@f0825000 {
 			device_type = "network";
 			compatible = "nuvoton,npcm750-emc";

--- a/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
@@ -1,14 +1,13 @@
 // SPDX-License-Identifier: GPL-2.0
-// Copyright (c) 2019 Nuvoton Technology kwliu@nuvoton.com
-// Copyright (c) 2020 Quanta Computer Inc. Eddie.Lu@quantatw.com
+// Copyright (c) 2020 Quanta Computer Inc. George.Hung@quantatw.com
 
 /dts-v1/;
 #include "nuvoton-npcm730.dtsi"
 #include <dt-bindings/gpio/gpio.h>
 
 / {
-	model = "Quanta GBS Board (Device Tree v01.00)";
-	compatible = "nuvoton,npcm750";
+	model = "Quanta GBS Board (Device Tree)";
+	compatible = "quanta,gbs-bmc","nuvoton,npcm730";
 
 	aliases {
 		ethernet0 = &emc0;
@@ -37,8 +36,6 @@
 		i2c13 = &i2c13;
 		i2c14 = &i2c14;
 		i2c15 = &i2c15;
-		fiu0 = &fiu0;
-		fiu1 = &fiu3;
 		i2c16 = &i2c0_slotPE0_0;
 		i2c17 = &i2c0_slotPE1_1;
 		i2c18 = &i2c0_slotUSB_2;
@@ -71,6 +68,8 @@
 		i2c45 = &i2c14_u2_2_1;
 		i2c46 = &i2c14_u2_1_2;
 		i2c47 = &i2c14_u2_0_3;
+		fiu0 = &fiu0;
+		fiu1 = &fiu3;
 	};
 
 	chosen {
@@ -81,48 +80,30 @@
 		reg = <0 0x40000000>;
 	};
 
-	soc {
-		gcr: gcr@800000 { /* GCR_BA, System Global Control Registers */
-			serial_port_mux: uart-mux-controller {
-				compatible = "mmio-mux";
-				#mux-control-cells = <1>;
-				mux-reg-masks = <0x38 0x07>;
-				idle-states = <2>; /* Serial port mode 3 (takeover) */
-			};
-
-			uart1_mode_mux: uart1-mode-mux-controller {
-				compatible = "mmio-mux";
-				#mux-control-cells = <1>;
-				mux-reg-masks = <0x64 0x01000000>;
-				idle-states = <0>; /* Set UART1 mode to normal (follow SPMOD) */
-			};
-		};
-	};
-
 	gpio-keys {
 		compatible = "gpio-keys";
 		sas-cable0 {
 			label = "sas-cable0";
-			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
-			linux,code = <70>;
+			gpios = <&gpio2 9 GPIO_ACTIVE_LOW>;
+			linux,code = <73>;
 		};
 
 		sas-cable1 {
 			label = "sas-cable1";
-			gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
-			linux,code = <71>;
-		};
-
-		sas-cable2 {
-			label = "sas-cable2";
 			gpios = <&gpio2 8 GPIO_ACTIVE_LOW>;
 			linux,code = <72>;
 		};
 
+		sas-cable2 {
+			label = "sas-cable2";
+			gpios = <&gpio2 7 GPIO_ACTIVE_LOW>;
+			linux,code = <71>;
+		};
+
 		sas-cable3 {
 			label = "sas-cable3";
-			gpios = <&gpio2 9 GPIO_ACTIVE_LOW>;
-			linux,code = <73>;
+			gpios = <&gpio2 6 GPIO_ACTIVE_LOW>;
+			linux,code = <70>;
 		};
 
 		sata0 {
@@ -172,25 +153,9 @@
 		io-channels = <&adc 0>;
 	};
 
-	jtag_master { /* Connect to CPLD by using GPIO */
-		compatible = "nuvoton,npcm750-jtag-master";
-		#address-cells = <1>;
-		#size-cells = <1>;
-
-		dev-num = <0>; /* /dev/jtag0 */
-		mode = "gpio"; /* pspi or gpio */
-
-		jtag-gpios = <&gpio7 0 GPIO_ACTIVE_HIGH>, /* TCK - gpio224 */
-				<&gpio7 3 GPIO_ACTIVE_HIGH>, /* TDI - gpio227 */
-				<&gpio7 4 GPIO_ACTIVE_HIGH>, /* TDO - gpio228 */
-				<&gpio7 6 GPIO_ACTIVE_HIGH>; /* TMS - gpio230 */
-
-		status = "okay";
-	};
-
 	leds {
 		compatible = "gpio-leds";
-		
+
 		heartbeat { /* gpio153 */
 			gpios = <&gpio4 25 GPIO_ACTIVE_LOW>;
 			linux,default-trigger = "heartbeat";
@@ -213,7 +178,7 @@
 			linux,default-trigger = "panic";
 			panic-indicator;
 		};
-		
+
 		led_u2_0_locate {
 			gpios = <&pca9535_ledlocate 3 GPIO_ACTIVE_LOW>;
 			default-state = "off";
@@ -392,964 +357,837 @@
 			label = "PE1";
 		};
 	};
+};
 
-	ahb { /* AHB Matrix */
-		fiu0: fiu@fb000000 { /* SPI0_BA, FIU0 (for SPI0) Registers ; FIU (Flash Interface Unit) */
-			pinctrl-names = "default";
-			pinctrl-0 = <&spi0cs1_pins>;
-			status = "okay";
-			spi-nor@0 {
-				compatible = "jedec,spi-nor";
-				#address-cells = <1>;
-				#size-cells = <1>;
-				reg = <0>;
-				spi-max-frequency = <19000000>;
-				spi-rx-bus-width = <2>;
-				label = "bmc";
-				partitions@80000000 {
-					compatible = "fixed-partitions";
-					#address-cells = <1>;
-					#size-cells = <1>;
-					u-boot@0 {
-						label = "u-boot";
-						reg = <0x0000000 0x80000>;
-					};
-					u-boot-env@100000{
-						label = "u-boot-env";
-						reg = <0x00100000 0x40000>;
-					};
-					kernel@200000 {
-						label = "kernel";
-						reg = <0x0200000 0x500000>;
-					};
-					rofs@720000 {
-						label = "rofs";
-						reg = <0x720000 0x34e0000>;
-					};
-					rwfs@3c00000 {
-						label = "rwfs";
-						reg = <0x3c00000 0x300000>;
-					};
-					reserved@3f00000 {
-						label = "reserved";
-						reg = <0x3f00000 0x100000>;
-					};
-				};
+&fiu0 {
+	pinctrl-names = "default";
+	pinctrl-0 = <&spi0cs1_pins>;
+	status = "okay";
+	spi-nor@0 {
+		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <19000000>;
+		spi-rx-bus-width = <2>;
+		label = "bmc";
+		partitions@80000000 {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			u-boot@0 {
+				label = "u-boot";
+				reg = <0x0000000 0xf0000>;
 			};
-		};
-
-		fiu3: fiu@c0000000 { /* SPI3_BA, FIU3 (for SPI3) Registers */
-			pinctrl-0 = <&spi3_pins>, <&spi3cs1_pins>;
-			status = "okay";
-
-			spi-nor@0 {
-				compatible = "jedec,spi-nor";
-				#address-cells = <1>;
-				#size-cells = <1>;
-				reg = <0>;
-				spi-max-frequency = <50000000>;
-				spi-rx-bus-width = <2>;
-				m25p,fast-read;
-				label = "pnor";
+			image-descriptor@f0000 {
+				label = "image-descriptor";
+				reg = <0xf0000 0x10000>;
 			};
-			spi-nor@1 {
-				compatible = "jedec,spi-nor";
-				#address-cells = <1>;
-				#size-cells = <1>;
-				reg = <1>;
-				spi-max-frequency = <50000000>;
-				spi-rx-bus-width = <2>;
-				m25p,fast-read;
+			hoth-update@100000 {
+				label = "hoth-update";
+				reg = <0x100000 0x100000>;
 			};
-		};
-
-		gmac0: eth@f0802000 { /* [gmac0: eth@f0802000] GMAC1_BA, Gigabit Ethernet MAC 1 (GMAC1) Control Registers */
-			status = "okay";
-			phy-mode = "rgmii-id";
-			snps,eee-force-disable;
-		};
-
-		emc0: eth@f0825000 { /* [emc0: eth@f0825000] EMC1_BA, Ethernet 10/100 MAC Controller (EMC1) Registers */
-			status = "okay";
-			phy-mode = "rmii";
-			use-ncsi;
-		};
-
-		mc: memory-controller@f0824000 { /* MC_BA, Memory Controller DDR4 Protocol Controller Registers */
-			compatible = "nuvoton,npcm7xx-sdram-edac";
-			reg = <0xf0824000 0x1000>;
-			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
-		};
-
-		ehci1: usb@f0806000 { /* USBH_BA, USB Host Controller EHCI Registers */
-			status = "okay";
-		};
-
-		ohci1: ohci@f0807000 { /* USBHO_BA, USB Host Controller OHCI Registers */
-			status = "okay";
-		};
-
-		aes: aes@f0858000 { /* AES_BA, Advances Encryption Standard Encryption Accelerator (AES) */
-			status = "okay";
-		};
-
-		sha: sha@f085a000 { /* SHA_BA, SHA-1 and SHA-256 Accelerator (SHA) */
-			status = "okay";
-		};
-		
-		udc5:udc@f0835000 {
-			status = "okay";
-		};
-
-		udc6:udc@f0836000 {
-			status = "okay";
-		};
-
-		udc7:udc@f0837000 {
-			status = "okay";
-		};
-
-		udc8:udc@f0838000 {
-			status = "okay";
-		};
-
-		pcimbox: pcimbox@f0848000 { /* PCIMBX_AB, Internal AHB to PCI Mailbox RAM (16KB) and registers */
-			status = "okay";
-		};
-
-		apb { /* F000_0000h - */
-			watchdog1: watchdog@901C { /* F000_9000h - F000_9FFFh, TMR1_BA, Timer 1 Control Registers (Timer Module 1) */
-				status = "okay";
+			kernel@200000 {
+				label = "kernel";
+				reg = <0x200000 0x500000>;
 			};
-
-			rng: rng@b000 { /* RNG_BA, Random Number Generator Control Registers */
-				status = "okay";
+			rofs@700000 {
+				label = "rofs";
+				reg = <0x700000 0x35f0000>;
 			};
-
-			serial0: serial@1000 { /* UART0_BA, UART 0 Control Registers (Tx, Rx for console) */
-				status = "okay";
+			rwfs@3cf0000 {
+				label = "rwfs";
+				reg = <0x3cf0000 0x300000>;
 			};
-
-			serial1: serial@2000 { /* UART1_BA, UART 1 Control Registers (Tx, Rx and modem controls) */
-				status = "okay";
-			};
-
-			serial2: serial@3000 { /* UART2_BA, UART 2 Control Registers (Tx, Rx and modem controls) */
-				status = "okay";
-			};
-
-			serial3: serial@4000 { /* UART3_BA, UART 3 Control Registers (Tx, Rx and modem controls) */
-				status = "okay";
-			};
-
-			adc: adc@c000 { /* ADC_BA, ADC Control Registers */
-				#io-channel-cells = <1>;
-				status = "okay";
-			};
-
-			otp:otp@189000 { /* F018_9000h - F018_9FFFh, OTP1_BA, OTP ROM (Fuse) Registers (Key Storage Array) */
-				status = "okay";
-			};
-
-			lpc_kcs: lpc_kcs@7000 { /* F000_7000h - F000_7FFFh, KCS_BA, KCS Interface Control Registers */
-
-				kcs1: kcs1@0 {
-					status = "okay";
-				};
-
-				kcs2: kcs2@0 {
-					status = "okay";
-				};
-
-				kcs3: kcs3@0 {
-					status = "okay";
-				};
-			};
-
-			lpc_host: lpc_host@7000 {
-
-				lpc_bpc: lpc_bpc@40 {
-					monitor-ports = <0x80>;
-					status = "okay";
-				};
-			};
-
-			i2c0: i2c@80000 { /* SMB0_BA, SMBus 0 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				i2c-switch@71 {
-					compatible = "nxp,pca9546";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x71>;
-					i2c-mux-idle-disconnect;
-					/* GPIO 84: RST_PCA9546_CPU0_N */
-					reset-gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
-					
-					i2c0_slotPE0_0: i2c@0 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-						pcie-slot = &pcie1;
-					};
-					
-					i2c0_slotPE1_1: i2c@1 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-						pcie-slot = &pcie2;
-					};
-
-					i2c0_slotUSB_2: i2c@2 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-					};
-
-					i2c0_3: i2c@3 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-					};
-				};
-			};
-
-			i2c1: i2c@81000 { /* SMB1_BA, SMBus 1 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				pca9535_ifdet: pca9535-ifdet@24 {
-					compatible = "nxp,pca9535";
-					reg = <0x24>;
-					gpio-controller;
-					#gpio-cells = <2>;
-					
-					U41_P0_0 {
-						gpios = <0 0>;
-						input;
-					};
-					U41_P0_1 {
-						gpios = <1 0>;
-						input;
-					};
-					U41_P0_2 {
-						gpios = <2 0>;
-						input;
-					};
-					U41_P0_3 {
-						gpios = <3 0>;
-						input;
-					};
-					U41_P0_4 {
-						gpios = <4 0>;
-						output-high;
-					};
-					U41_P0_5 {
-						gpios = <5 0>;
-						input;
-					};
-					U41_P0_6 {
-						gpios = <6 0>;
-						input;
-					};
-					U41_P0_7 {
-						gpios = <7 0>;
-						input;
-					};
-					U41_P1_0 {
-						gpios = <8 0>;
-						input;
-					};
-					U41_P1_1 {
-						gpios = <9 0>;
-						input;
-					};
-					U41_P1_2 {
-						gpios = <10 0>;
-						input;
-					};
-					U41_P1_3 {
-						gpios = <11 0>;
-						input;
-					};
-					U41_P1_4 {
-						gpios = <12 0>;
-						input;
-					};
-					U41_P1_5 {
-						gpios = <13 0>;
-						input;
-					};
-					U41_P1_6 {
-						gpios = <14 0>;
-						input;
-					};
-					U41_P1_7 {
-						gpios = <15 0>;
-						input;
-					};
-				};
-				pca9535_pwren: pca9535-pwren@20 {
-					compatible = "nxp,pca9535";
-					reg = <0x20>;
-					gpio-controller;
-					#gpio-cells = <2>;
-					
-					gpio-line-names =
-						"pwr_u2_3_en","pwr_u2_2_en","pwr_u2_1_en","pwr_u2_0_en",
-						"pwr_u2_7_en","pwr_u2_6_en","pwr_u2_5_en","pwr_u2_4_en",
-						"pwr_u2_11_en","pwr_u2_10_en","pwr_u2_9_en","pwr_u2_8_en",
-						"pwr_u2_15_en","pwr_u2_14_en","pwr_u2_13_en","pwr_u2_12_en";
-				};
-				pca9535_pwrgd: pca9535-pwrgd@21 {
-					compatible = "nxp,pca9535";
-					reg = <0x21>;
-					gpio-controller;
-					#gpio-cells = <2>;
-					
-					U43_P0_0 {
-						gpios = <0 0>;
-						input;
-					};
-					U43_P0_1 {
-						gpios = <1 0>;
-						input;
-					};
-					U43_P0_2 {
-						gpios = <2 0>;
-						input;
-					};
-					U43_P0_3 {
-						gpios = <3 0>;
-						input;
-					};
-					U43_P0_4 {
-						gpios = <4 0>;
-						input;
-					};
-					U43_P0_5 {
-						gpios = <5 0>;
-						input;
-					};
-					U43_P0_6 {
-						gpios = <6 0>;
-						input;
-					};
-					U43_P0_7 {
-						gpios = <7 0>;
-						input;
-					};
-					U43_P1_0 {
-						gpios = <8 0>;
-						input;
-					};
-					U43_P1_1 {
-						gpios = <9 0>;
-						input;
-					};
-					U43_P1_2 {
-						gpios = <10 0>;
-						input;
-					};
-					U43_P1_3 {
-						gpios = <11 0>;
-						input;
-					};
-					U43_P1_4 {
-						gpios = <12 0>;
-						input;
-					};
-					U43_P1_5 {
-						gpios = <13 0>;
-						input;
-					};
-					U43_P1_6 {
-						gpios = <14 0>;
-						input;
-					};
-					U43_P1_7 {
-						gpios = <15 0>;
-						input;
-					};
-				};
-				pca9535_ledlocate: pca9535-ledlocate@22 {
-					compatible = "nxp,pca9535";
-					reg = <0x22>;
-					gpio-controller;
-					#gpio-cells = <2>;
-
-				};
-				pca9535_ledfault: pca9535-ledfault@23 {
-					compatible = "nxp,pca9535";
-					reg = <0x23>;
-					gpio-controller;
-					#gpio-cells = <2>;
-
-				};
-				pca9535_pwrdisable: pca9535-pwrdisable@25 {
-					compatible = "nxp,pca9535";
-					reg = <0x25>;
-					gpio-controller;
-					#gpio-cells = <2>;
-
-					gpio-line-names =
-						"u2_3_pwr_dis","u2_2_pwr_dis","u2_1_pwr_dis","u2_0_pwr_dis",
-						"u2_7_pwr_dis","u2_6_pwr_dis","u2_5_pwr_dis","u2_4_pwr_dis",
-						"u2_11_pwr_dis","u2_10_pwr_dis","u2_9_pwr_dis","u2_8_pwr_dis",
-						"u2_15_pwr_dis","u2_14_pwr_dis","u2_13_pwr_dis","u2_12_pwr_dis";
-				};
-				pca9535_perst: pca9535-perst@26 {
-					compatible = "nxp,pca9535";
-					reg = <0x26>;
-					gpio-controller;
-					#gpio-cells = <2>;
-
-					gpio-line-names =
-						"u2_3_perst","u2_2_perst","u2_1_perst","u2_0_perst",
-						"u2_7_perst","u2_6_perst","u2_5_perst","u2_4_perst",
-						"u2_11_perst","u2_10_perst","u2_9_perst","u2_8_perst",
-						"u2_15_perst","u2_14_perst","u2_13_perst","u2_12_perst";
-				};
-			};
-
-			i2c2: i2c@82000 { /* SMB2_BA, SMBus 2 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				sbtsi@4c {
-					compatible = "amd,sbtsi";
-					reg = <0x4c>;
-				};
-			};
-
-			i2c3: i2c@83000 { /* SMB3_BA, SMBus 3 Control Registers */
-				/* Connected to CPU DIMM SPDs via an i2c mux. No interest to enable. */
-				status = "disabled";
-			};
-
-			i2c4: i2c@84000 { /* SMB4_BA, SMBus 4 Control Registers */
-				/* Connected to CPU i2c. Not used. */
-				status = "disabled";
-			};
-
-			i2c5: i2c@85000 { /* SMB5_BA, SMBus 5 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-				
-				mb_fru@50 {
-					compatible = "atmel,24c128";
-					reg = <0x50>;
-				};
-
-				i2c-switch@71 {
-					compatible = "nxp,pca9546";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x71>;
-					i2c-mux-idle-disconnect;
-
-					i2c5_i2cool_0: i2c@0 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-						max31725@54 {
-							compatible = "maxim,max31725";
-							reg = <0x54>;
-							status = "okay";
-						};
-					};
-					i2c5_i2cool_1: i2c@1 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-						max31725@55 {
-							compatible = "maxim,max31725";
-							reg = <0x55>;
-							status = "okay";
-						};
-					};
-					i2c5_i2cool_2: i2c@2 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-						max31725@5d {
-							compatible = "maxim,max31725";
-							reg = <0x5d>;
-							status = "okay";
-						};
-						fan_fru@51 {
-							compatible = "atmel,24c128";
-							reg = <0x51>;
-						};
-					};
-					i2c5_hsbp_fru_3: i2c@3 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-						hsbp_fru@52 {
-							compatible = "atmel,24c128";
-							reg = <0x52>;
-							status = "okay";
-						};
-					};
-					
-				};
-			};
-
-			i2c6: i2c@86000 { /* SMB6_BA, SMBus 6 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				i2c-switch@73 {
-					compatible = "nxp,pca9545";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x73>;
-					i2c-mux-idle-disconnect;
-
-					i2c6_u2_15_0: i2c@0 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-					};
-
-					i2c6_u2_14_1: i2c@1 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-					};
-					i2c6_u2_13_2: i2c@2 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-					};
-
-					i2c6_u2_12_3: i2c@3 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-					};
-				};
-
-			};
-
-			i2c7: i2c@87000 { /* SMB7_BA, SMBus 7 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-				
-				i2c-switch@72 {
-					compatible = "nxp,pca9545";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x72>;
-					i2c-mux-idle-disconnect;
-
-					i2c7_u2_11_0: i2c@0 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-					};
-
-					i2c7_u2_10_1: i2c@1 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-					};
-					i2c7_u2_9_2: i2c@2 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-					};
-
-					i2c7_u2_8_3: i2c@3 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-					};
-				};
-			};
-
-			i2c8: i2c@88000 { /* SMB8_BA, SMBus 8 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				i2c8_adm1272: adm1272@10 {
-					compatible = "adi,adm1272";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x10>;
-					shunt-resistor-micro-ohms = <300>;
-				};
-			};
-
-			i2c9: i2c@89000 { /* SMB9_BA, SMBus 9 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				i2c-switch@71 {
-					compatible = "nxp,pca9546";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x71>;
-					i2c-mux-idle-disconnect;
-					/* GPIO86: RST_PCA9546_CPU0_VR_N */
-					reset-gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
-
-					i2c9_vddcr_cpu: i2c@0 { /* ISL690247_ISL99390*7 */
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-						vrm@60 {
-							compatible = "isil,isl68137";
-							reg = <0x60>;
-						};
-					};
-
-					i2c9_vddcr_soc: i2c@1 { /* ISL69243_ISL99390*3 */
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-						vrm@61 {
-							compatible = "isil,isl68137";
-							reg = <0x61>;
-						};
-					};
-
-					i2c9_vddio_efgh: i2c@2 { /* ISL69225_ISL99380*4_ISL99360*1 */
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-						vrm@63 {
-							compatible = "isil,isl68137";
-							reg = <0x63>;
-						};
-					};
-
-					i2c9_vddio_abcd: i2c@3 { /* ISL69225_ISL99380*4_ISL99360*1 */
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-						vrm@45 {
-							compatible = "isil,isl68137";
-							reg = <0x45>;
-						};
-					};
-				};
-
-			};
-
-			i2c10: i2c@8a000 { /* SMB10_BA, SMBus 10 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				i2c-switch@71 {
-					compatible = "nxp,pca9545";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x71>;
-					i2c-mux-idle-disconnect;
-
-					i2c10_u2_7_0: i2c@0 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-					};
-
-					i2c10_u2_6_1: i2c@1 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-					};
-					i2c10_u2_5_2: i2c@2 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-					};
-
-					i2c10_u2_4_3: i2c@3 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-					};
-				};
-			};
-
-			i2c11: i2c@8b000 { /* SMB11_BA, SMBus 11 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-				
-				i2c-switch@76 {
-					compatible = "nxp,pca9545";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x76>;
-					i2c-mux-idle-disconnect;
-
-					i2c11_clk_buf0_0: i2c@0 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-					};
-
-					i2c11_clk_buf1_1: i2c@1 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-					};
-					i2c11_clk_buf2_2: i2c@2 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-					};
-
-					i2c11_clk_buf3_3: i2c@3 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-					};
-				};
-			};
-
-			i2c12: i2c@8c000 { /* SMB12_BA, SMBus 12 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-
-				max34451@4e {
-					compatible = "maxim,max34451";
-					reg = <0x4e>;
-				};
-				
-				vrm@5d {
-					compatible = "isil,isl68137";
-					reg = <0x5d>;
-				};
-				vrm@5e {
-					compatible = "isil,isl68137";
-					reg = <0x5e>;
-				};
-			};
-
-			i2c13: i2c@8d000 { /* SMB13_BA, SMBus 13 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-			};
-
-			i2c14: i2c@8e000 { /* SMB14_BA, SMBus 14 Control Registers */
-				#address-cells = <1>;
-				#size-cells = <0>;
-				bus-frequency = <100000>;
-				status = "okay";
-				i2c-switch@70 {
-					compatible = "nxp,pca9545";
-					#address-cells = <1>;
-					#size-cells = <0>;
-					reg = <0x70>;
-					i2c-mux-idle-disconnect;
-
-					i2c14_u2_3_0: i2c@0 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <0>;
-					};
-
-					i2c14_u2_2_1: i2c@1 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <1>;
-					};
-					i2c14_u2_1_2: i2c@2 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <2>;
-					};
-
-					i2c14_u2_0_3: i2c@3 {
-						#address-cells = <1>;
-						#size-cells = <0>;
-						reg = <3>;
-					};
-				};
-			};
-
-			i2c15: i2c@8f000 { /* SMB15_BA, SMBus 15 Control Registers */
-				/* Nothing connected. */
-				status = "disabled";
-			};
-
-			pwm_fan:pwm-fan-controller@103000 { /* F010_3000h - F010_3FFFh, PWMM0_BA, Pulse Width Modulation (PWM) Module 0 Control Registers */
-				pinctrl-names = "default";
-				pinctrl-0 = <
-					&pwm0_pins &pwm1_pins
-					&pwm2_pins &pwm3_pins
-					&pwm4_pins
-					&fanin0_pins &fanin1_pins
-					&fanin2_pins &fanin3_pins
-					&fanin4_pins
-				>;
-				status = "okay";
-				
-				fan@0 {
-					reg = <0x00>;
-					fan-tach-ch = /bits/ 8 <0x00>;
-					// cooling-levels = /bits/ 8 <127 255>;
-				};
-
-				fan@1 {
-					reg = <0x01>;
-					fan-tach-ch = /bits/ 8 <0x01>;
-					// cooling-levels = /bits/ 8 <127 255>;
-				};
-
-				fan@2 {
-					reg = <0x02>;
-					fan-tach-ch = /bits/ 8 <0x02>;
-					// cooling-levels = /bits/ 8 <127 255>;
-				};
-				fan@3 {
-					reg = <0x03>;
-					fan-tach-ch = /bits/ 8 <0x03>;
-					// cooling-levels = /bits/ 8 <127 255>;
-				};
-
-				fan@4 {
-					reg = <0x04>;
-					fan-tach-ch = /bits/ 8 <0x04>;
-					// cooling-levels = /bits/ 8 <127 255>;
-				};
+			hoth-mailbox@3ff0000 {
+				label = "hoth-mailbox";
+				reg = <0x3ff0000 0x10000>;
 			};
 		};
 	};
+};
 
-	pinctrl: pinctrl@f0800000 { /* AHB Matrix (part 2) */
+&fiu3 {
+	pinctrl-0 = <&spi3_pins>, <&spi3cs1_pins>;
+	status = "okay";
+
+	spi-nor@0 {
+		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <0>;
+		spi-max-frequency = <50000000>;
+		spi-rx-bus-width = <2>;
+		m25p,fast-read;
+		label = "pnor";
+	};
+	spi-nor@1 {
+		compatible = "jedec,spi-nor";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		reg = <1>;
+		spi-max-frequency = <50000000>;
+		spi-rx-bus-width = <2>;
+		m25p,fast-read;
+	};
+};
+
+&gcr {
+	serial_port_mux: uart-mux-controller {
+		compatible = "mmio-mux";
+		#mux-control-cells = <1>;
+		mux-reg-masks = <0x38 0x07>;
+		idle-states = <2>; /* Serial port mode 3 (takeover) */
+	};
+
+	uart1_mode_mux: uart1-mode-mux-controller {
+		compatible = "mmio-mux";
+		#mux-control-cells = <1>;
+		mux-reg-masks = <0x64 0x01000000>;
+		idle-states = <0>; /* Set UART1 mode to normal (follow SPMOD) */
+	};
+};
+
+&gmac0 {
+	status = "okay";
+	phy-mode = "rgmii-id";
+	snps,eee-force-disable;
+};
+
+&emc0 {
+	status = "okay";
+	phy-mode = "rmii";
+	use-ncsi;
+};
+
+&mc {
+	status = "okay";
+};
+
+&ehci1 {
+	status = "okay";
+};
+
+&ohci1 {
+	status = "okay";
+};
+
+&aes {
+	status = "okay";
+};
+
+&sha {
+	status = "okay";
+};
+
+&udc5 {
+	status = "okay";
+};
+
+&udc6 {
+	status = "okay";
+};
+
+&udc7 {
+	status = "okay";
+};
+
+&udc8 {
+	status = "okay";
+};
+
+&pcimbox {
+	status = "okay";
+};
+
+&watchdog1 {
+	status = "okay";
+};
+
+&rng {
+	status = "okay";
+};
+
+&serial0 {
+	status = "okay";
+};
+
+&serial1 {
+	status = "okay";
+};
+
+&serial2 {
+	status = "okay";
+};
+
+&serial3 {
+	status = "okay";
+};
+
+&adc {
+	#io-channel-cells = <1>;
+	status = "okay";
+};
+
+&otp {
+	status = "okay";
+};
+
+&lpc_kcs {
+	kcs1: kcs1@0 {
 		status = "okay";
-		pinctrl-names = "default";
+	};
 
-		gpio0: gpio@f0010000 {
-			/* POWER_OUT=gpio07, RESET_OUT=gpio06, PS_PWROK=gpio13 (ALL_POWER_GOOD_BMC) */
-			gpio-line-names =
-			/*0-31*/
-			"","","","","","","RESET_OUT","POWER_OUT",
-			"","","","","","PS_PWROK","","",
+	kcs2: kcs2@0 {
+		status = "okay";
+	};
+
+	kcs3: kcs3@0 {
+		status = "okay";
+	};
+};
+
+&lpc_host {
+	lpc_bpc: lpc_bpc@40 {
+		monitor-ports = <0x80>;
+		status = "okay";
+	};
+};
+
+&spi1 {
+	cs-gpios = <&gpio4 19 GPIO_ACTIVE_HIGH>; /* dummy - gpio147 */
+	pinctrl-names = "default";
+	pinctrl-0 = <&gpio224ol_pins &gpio227o_pins
+			&gpio228_pins>;
+	status = "okay";
+
+	jtag_master@0 {
+		compatible = "nuvoton,npcm750-jtag-master";
+		spi-max-frequency = <25000000>;
+		reg = <0>;
+		status = "okay";
+
+		pinctrl-names = "pspi", "gpio";
+		pinctrl-0 = <&pspi2_pins>;
+		pinctrl-1 = <&gpio224ol_pins &gpio227o_pins
+				&gpio228_pins>;
+
+		tck-gpios = <&gpio7 0 GPIO_ACTIVE_HIGH>;
+		tdi-gpios = <&gpio7 3 GPIO_ACTIVE_HIGH>;
+		tdo-gpios = <&gpio7 4 GPIO_ACTIVE_HIGH>;
+		tms-gpios = <&gpio7 6 GPIO_ACTIVE_HIGH>;
+	};
+};
+
+&i2c0 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c-switch@71 {
+		compatible = "nxp,pca9546";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x71>;
+		i2c-mux-idle-disconnect;
+		reset-gpios = <&gpio2 20 GPIO_ACTIVE_LOW>;
+
+		i2c0_slotPE0_0: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+			pcie-slot = &pcie1;
+		};
+
+		i2c0_slotPE1_1: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			pcie-slot = &pcie2;
+		};
+
+		i2c0_slotUSB_2: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+
+		i2c0_3: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&i2c1 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	pca9535_ifdet: pca9535-ifdet@24 {
+		compatible = "nxp,pca9535";
+		reg = <0x24>;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+
+	pca9535_pwren: pca9535-pwren@20 {
+		compatible = "nxp,pca9535";
+		reg = <0x20>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		gpio-line-names =
+			"pwr_u2_3_en","pwr_u2_2_en",
+			"pwr_u2_1_en","pwr_u2_0_en",
+			"pwr_u2_7_en","pwr_u2_6_en",
+			"pwr_u2_5_en","pwr_u2_4_en",
+			"pwr_u2_11_en","pwr_u2_10_en",
+			"pwr_u2_9_en","pwr_u2_8_en",
+			"pwr_u2_15_en","pwr_u2_14_en",
+			"pwr_u2_13_en","pwr_u2_12_en";
+	};
+
+	pca9535_pwrgd: pca9535-pwrgd@21 {
+		compatible = "nxp,pca9535";
+		reg = <0x21>;
+		gpio-controller;
+		#gpio-cells = <2>;
+	};
+
+	pca9535_ledlocate: pca9535-ledlocate@22 {
+		compatible = "nxp,pca9535";
+		reg = <0x22>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+	};
+
+	pca9535_ledfault: pca9535-ledfault@23 {
+		compatible = "nxp,pca9535";
+		reg = <0x23>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+	};
+
+	pca9535_pwrdisable: pca9535-pwrdisable@25 {
+		compatible = "nxp,pca9535";
+		reg = <0x25>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		gpio-line-names =
+			"u2_3_pwr_dis","u2_2_pwr_dis",
+			"u2_1_pwr_dis","u2_0_pwr_dis",
+			"u2_7_pwr_dis","u2_6_pwr_dis",
+			"u2_5_pwr_dis","u2_4_pwr_dis",
+			"u2_11_pwr_dis","u2_10_pwr_dis",
+			"u2_9_pwr_dis","u2_8_pwr_dis",
+			"u2_15_pwr_dis","u2_14_pwr_dis",
+			"u2_13_pwr_dis","u2_12_pwr_dis";
+	};
+
+	pca9535_perst: pca9535-perst@26 {
+		compatible = "nxp,pca9535";
+		reg = <0x26>;
+		gpio-controller;
+		#gpio-cells = <2>;
+
+		gpio-line-names =
+			"u2_15_perst","u2_14_perst",
+			"u2_13_perst","u2_12_perst",
+			"u2_11_perst","u2_10_perst",
+			"u2_9_perst","u2_8_perst",
+			"u2_7_perst","u2_6_perst",
+			"u2_5_perst","u2_4_perst",
+			"u2_3_perst","u2_2_perst",
+			"u2_1_perst","u2_0_perst";
+	};
+};
+
+&i2c2 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	sbtsi@4c {
+		compatible = "amd,sbtsi";
+		reg = <0x4c>;
+	};
+};
+
+&i2c5 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	mb_fru@50 {
+		compatible = "atmel,24c64";
+		reg = <0x50>;
+	};
+
+	i2c-switch@71 {
+		compatible = "nxp,pca9546";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x71>;
+		i2c-mux-idle-disconnect;
+
+		i2c5_i2cool_0: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+			max31725@54 {
+				compatible = "maxim,max31725";
+				reg = <0x54>;
+				status = "okay";
+			};
+		};
+
+		i2c5_i2cool_1: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			max31725@55 {
+				compatible = "maxim,max31725";
+				reg = <0x55>;
+				status = "okay";
+			};
+		};
+
+		i2c5_i2cool_2: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+			max31725@5d {
+				compatible = "maxim,max31725";
+				reg = <0x5d>;
+				status = "okay";
+			};
+			fan_fru@51 {
+				compatible = "atmel,24c64";
+				reg = <0x51>;
+			};
+		};
+
+		i2c5_hsbp_fru_3: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+			hsbp_fru@52 {
+				compatible = "atmel,24c64";
+				reg = <0x52>;
+				status = "okay";
+			};
+		};
+	};
+};
+
+&i2c6 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c-switch@73 {
+		compatible = "nxp,pca9545";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x73>;
+		i2c-mux-idle-disconnect;
+
+		i2c6_u2_15_0: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+
+		i2c6_u2_14_1: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c6_u2_13_2: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+
+		i2c6_u2_12_3: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&i2c7 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c-switch@72 {
+		compatible = "nxp,pca9545";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x72>;
+		i2c-mux-idle-disconnect;
+
+		i2c7_u2_11_0: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+
+		i2c7_u2_10_1: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c7_u2_9_2: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+
+		i2c7_u2_8_3: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&i2c8 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c8_adm1272: adm1272@10 {
+		compatible = "adi,adm1272";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x10>;
+		shunt-resistor-micro-ohms = <300>;
+	};
+};
+
+&i2c9 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c-switch@71 {
+		compatible = "nxp,pca9546";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x71>;
+		i2c-mux-idle-disconnect;
+		reset-gpios = <&gpio2 22 GPIO_ACTIVE_LOW>;
+
+		i2c9_vddcr_cpu: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+			vrm@60 {
+				compatible = "isil,isl68137";
+				reg = <0x60>;
+			};
+		};
+
+		i2c9_vddcr_soc: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+			vrm@61 {
+				compatible = "isil,isl68137";
+				reg = <0x61>;
+			};
+		};
+
+		i2c9_vddio_efgh: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+			vrm@63 {
+				compatible = "isil,isl68137";
+				reg = <0x63>;
+			};
+		};
+
+		i2c9_vddio_abcd: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+			vrm@45 {
+				compatible = "isil,isl68137";
+				reg = <0x45>;
+			};
+		};
+	};
+};
+
+&i2c10 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c-switch@71 {
+		compatible = "nxp,pca9545";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x71>;
+		i2c-mux-idle-disconnect;
+
+		i2c10_u2_7_0: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+
+		i2c10_u2_6_1: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c10_u2_5_2: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+
+		i2c10_u2_4_3: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&i2c11 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c-switch@76 {
+		compatible = "nxp,pca9545";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x76>;
+		i2c-mux-idle-disconnect;
+
+		i2c11_clk_buf0_0: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+
+		i2c11_clk_buf1_1: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+		i2c11_clk_buf2_2: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+
+		i2c11_clk_buf3_3: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&i2c12 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	max34451@4e {
+		compatible = "maxim,max34451";
+		reg = <0x4e>;
+	};
+	vrm@5d {
+		compatible = "isil,isl68137";
+		reg = <0x5d>;
+	};
+	vrm@5e {
+		compatible = "isil,isl68137";
+		reg = <0x5e>;
+	};
+};
+
+&i2c13 {
+	clock-frequency = <100000>;
+	status = "okay";
+};
+
+&i2c14 {
+	clock-frequency = <100000>;
+	status = "okay";
+
+	i2c-switch@70 {
+		compatible = "nxp,pca9545";
+		#address-cells = <1>;
+		#size-cells = <0>;
+		reg = <0x70>;
+		i2c-mux-idle-disconnect;
+
+		i2c14_u2_3_0: i2c@0 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <0>;
+		};
+
+		i2c14_u2_2_1: i2c@1 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <1>;
+		};
+
+		i2c14_u2_1_2: i2c@2 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <2>;
+		};
+
+		i2c14_u2_0_3: i2c@3 {
+			#address-cells = <1>;
+			#size-cells = <0>;
+			reg = <3>;
+		};
+	};
+};
+
+&pwm_fan {
+	pinctrl-names = "default";
+	pinctrl-0 = <
+		&pwm0_pins &pwm1_pins
+		&pwm2_pins &pwm3_pins
+		&pwm4_pins
+		&fanin0_pins &fanin1_pins
+		&fanin2_pins &fanin3_pins
+		&fanin4_pins
+	>;
+	status = "okay";
+
+	fan@0 {
+		reg = <0x00>;
+		fan-tach-ch = /bits/ 8 <0x00>;
+	};
+	fan@1 {
+		reg = <0x01>;
+		fan-tach-ch = /bits/ 8 <0x01>;
+	};
+	fan@2 {
+		reg = <0x02>;
+		fan-tach-ch = /bits/ 8 <0x02>;
+	};
+	fan@3 {
+		reg = <0x03>;
+		fan-tach-ch = /bits/ 8 <0x03>;
+	};
+	fan@4 {
+		reg = <0x04>;
+		fan-tach-ch = /bits/ 8 <0x04>;
+	};
+};
+
+&pinctrl {
+	pinctrl-names = "default";
+
+	gpio0: gpio@f0010000 {
+		/* POWER_OUT=gpio07, RESET_OUT=gpio06, PS_PWROK=gpio13 */
+		gpio-line-names =
+		/*0-31*/
+		"","","","","","","RESET_OUT","POWER_OUT",
+		"","","","","","PS_PWROK","","",
+		"","","","","","","","",
+		"","","","","","","","";
+	};
+	gpio1: gpio@f0011000 {
+		/* SIO_POWER_GOOD=gpio59 */
+		gpio-line-names =
+		/*32-63*/
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","","","","","",
+		"","","","SIO_POWER_GOOD","","","","";
+	};
+	gpio2: gpio@f0012000 {
+		bmc_usb_mux_oe_n {
+			gpio-hog;
+			gpios = <25 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "bmc-usb-mux-oe-n";
+		};
+		bmc_usb_mux_sel {
+			gpio-hog;
+			gpios = <26 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "bmc-usb-mux-sel";
+		};
+		bmc_usb2517_reset_n {
+			gpio-hog;
+			gpios = <27 GPIO_ACTIVE_LOW>;
+			output-low;
+			line-name = "bmc-usb2517-reset-n";
+		};
+	};
+	gpio3: gpio@f0013000 {
+		assert_cpu0_reset {
+			gpio-hog;
+			gpios = <14 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "assert-cpu0-reset";
+		};
+		assert_pwrok_cpu0_n {
+			gpio-hog;
+			gpios = <15 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "assert-pwrok-cpu0-n";
+		};
+		assert_cpu0_prochot {
+			gpio-hog;
+			gpios = <16 GPIO_ACTIVE_HIGH>;
+			output-low;
+			line-name = "assert-cpu0-prochot";
+		};
+	};
+	gpio4: gpio@f0014000 {
+		/* POST_COMPLETE=gpio143 */
+		gpio-line-names =
+			/*128-159*/
+			"","","","","","","","",
+			"","","","","","","","POST_COMPLETE",
 			"","","","","","","","",
 			"","","","","","","","";
-		};
-		gpio1: gpio@f0011000 {
-			/* SIO_POWER_GOOD=gpio59 (PWRGD_OUT_CPU_BMC) */
-			gpio-line-names =
-			/*32-63*/
+	};
+	gpio5: gpio@f0015000 {
+		/* POWER_BUTTON=gpio177 */
+		gpio-line-names =
+			/*160-191*/
 			"","","","","","","","",
 			"","","","","","","","",
+			"","POWER_BUTTON","","","","","","",
+			"","","","","","","","";
+	};
+	gpio6: gpio@f0016000 {
+		/* SIO_S5=gpio199, RESET_BUTTON=gpio203 */
+		gpio-line-names =
+			/*192-223*/
+			"","","","","","","","SIO_S5",
+			"","","","RESET_BUTTON","","","","",
 			"","","","","","","","",
-			"","","","SIO_POWER_GOOD","","","","";
-		};
-		gpio2: gpio@f0012000 {
-			/* Hog GPIOs for USB mux. GPIOs 89-91 are part of gpio2 which controls
-			* GPIOs 64-95 (specified by gpio-ranges) defined in
-			* nuvoton-common-npcm7xx.dtsi:784:
-			*
-			*    gpio2: gpio@f0012000 {
-			*       ...
-			*       gpio-ranges = <&pinctrl 0 64 32>;
-			*    };
-			*
-			* 89 - 64 = 25 is then the offset for GPIO 89 in gpio2 and so on. */
+			"","","","","","","","";
+	};
 
-			bmc_usb_mux_oe_n {
-				gpio-hog;
-				gpios = <25 GPIO_ACTIVE_HIGH>; /* GPIO89 */
-				output-low;
-				line-name = "bmc-usb-mux-oe-n";
-			};
-
-			bmc_usb_mux_sel {
-				gpio-hog;
-				gpios = <26 GPIO_ACTIVE_HIGH>; /* GPIO90 */
-				output-low;
-				line-name = "bmc-usb-mux-sel";
-			};
-
-			bmc_usb2517_reset_n {
-				gpio-hog;
-				gpios = <27 GPIO_ACTIVE_LOW>; /* GPIO91 */
-				output-low;
-				line-name = "bmc-usb2517-reset-n";
-			};
-
-		};
-		gpio3: gpio@f0013000 {
-			/* Hog GPIOs 110-112 (ASSERT*) to low to avoid disturbing FET gates.*/
-			assert_cpu0_reset {
-				gpio-hog;
-				gpios = <14 GPIO_ACTIVE_HIGH>; /* GPIO110 */
-				output-low;
-				line-name = "assert-cpu0-reset";
-			};
-
-			assert_pwrok_cpu0_n {
-				gpio-hog;
-				gpios = <15 GPIO_ACTIVE_HIGH>; /* GPIO111 */
-				output-low;
-				line-name = "assert-pwrok-cpu0-n";
-			};
-
-			assert_cpu0_prochot {
-				gpio-hog;
-				gpios = <16 GPIO_ACTIVE_HIGH>; /* GPIO112 */
-				output-low;
-				line-name = "assert-cpu0-prochot";
-			};
-		};
-		gpio4: gpio@f0014000 {
-			/* POST_COMPLETE=gpio143 */
-			gpio-line-names =
-				/*128-159*/
-				"","","","","","","","",
-				"","","","","","","","POST_COMPLETE",
-				"","","","","","","","",
-				"","","","","","","","";
-		};
-		gpio5: gpio@f0015000 {
-			/* POWER_BUTTON=gpio177 */
-			gpio-line-names =
-				/*160-191*/
-				"","","","","","","","",
-				"","","","","","","","",
-				"","POWER_BUTTON","","","","","","",
-				"","","","","","","","";
-		};
-		gpio6: gpio@f0016000 {
-			/* SIO_S5=gpio199 (CPU0_SLP_S5_N),RESET_BUTTON=gpio203 */
-			gpio-line-names =
-				/*192-223*/
-				"","","","","","","","SIO_S5",
-				"","","","RESET_BUTTON","","","","",
-				"","","","","","","","",
-				"","","","","","","","";
-		};
+	gpio224ol_pins: gpio224ol-pins {
+		pins = "GPIO224/SPIXCK";
+		bias-disable;
+		output-low;
+	};
+	gpio227o_pins: gpio227o-pins {
+		pins = "GPIO227/nSPIXCS0";
+		bias-disable;
+		output-high;
+	};
+	gpio228_pins: gpio228-pins {
+		pins = "GPIO228/nSPIXCS1";
+		bias-disable;
+		input-enable;
 	};
 };

--- a/arch/arm/boot/dts/nuvoton-npcm730.dtsi
+++ b/arch/arm/boot/dts/nuvoton-npcm730.dtsi
@@ -87,7 +87,7 @@
 		udc9:udc@f0839000 {
 			compatible = "nuvoton,npcm750-udc";
 			reg = <0xf0839000 0x1000
-			       0xfffd0000 0x800>;
+			       0xfffd4800 0x800>;
 			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 			clocks = <&clk NPCM7XX_CLK_SU>;


### PR DESCRIPTION
- add the machine name to compatible string
- follow the convention of using phandles to enable devices
- fix udc9 device nodes register address to nuvoton-npcm730.dtsi
- fix fru eeprom device type
- work-around sas cable gpios config
- update the flash layout
- update jtag dts config for the new jtag driver
- add mc general config to nuvoton-common-npcm7xx.dtsi

Signed-off-by: George Hung <george.hung@quantatw.com>