### PR TITLE
dts:npcm730-gbs: add fans-efuse GPIO to gpio-keys

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
@@ -141,6 +141,12 @@
 			gpios = <&gpio3 25 GPIO_ACTIVE_LOW>;
 			linux,code = <121>;
 		};
+
+		fans-efuse {
+			label = "fans-efuse";
+			gpios = <&gpio4 18 GPIO_ACTIVE_HIGH>;
+			linux,code = <146>;
+		};
 	};
 
 	iio-hwmon {


### PR DESCRIPTION
Signed-off-by: George Hung <george.hung@quantatw.com>