### PR TITLE
dts:npcm730-gbs: add PCIe slot power GPIO to gpio-keys

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
@@ -147,6 +147,12 @@
 			gpios = <&gpio4 18 GPIO_ACTIVE_HIGH>;
 			linux,code = <146>;
 		};
+
+		pwrgd_p12v_slots {
+			label = "pwrgd_p12v_slots";
+			gpios = <&gpio2 24 GPIO_ACTIVE_HIGH>;
+			linux,code = <88>;
+		};
 	};
 
 	iio-hwmon {


### PR DESCRIPTION
Add PCIe slot power GPIO (pwrgd_p12v_slots) to gpio-keys

Signed-off-by: George Hung <george.hung@quantatw.com>