### PR TITLE
dts: npcm730-gbs: update emc0 as fixed link

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
@@ -468,8 +468,10 @@
 
 &emc0 {
 	status = "okay";
-	phy-mode = "rmii";
-	use-ncsi;
+	fixed-link {
+		speed = <100>;
+		full-duplex;
+	};
 };
 
 &mc {


### PR DESCRIPTION
Update the emc0 to support PHY patch added in
ref: https://lore.kernel.org/patchwork/patch/1381862/
ref: https://github.com/openbmc/linux/commit/44f863d74c2a060b884d44cd58aba92d5d1c1e28

Signed-off-by: George Hung <george.hung@quantatw.com>