### PR TITLE
dts: npcm730-gbs: split SPI flash partition

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm730-gbs.dts
@@ -432,6 +432,19 @@
 		spi-rx-bus-width = <2>;
 		m25p,fast-read;
 		label = "pnor";
+		partitions@a0000000 {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			pnor-primary@0 {
+				label = "pnor-primary";
+				reg = <0x0000000 0x2000000>;
+			};
+			pnor-scratch@2000000 {
+				label = "pnor-scratch";
+				reg = <0x2000000 0x2000000>;
+			};
+		};
 	};
 	spi-nor@1 {
 		compatible = "jedec,spi-nor";
@@ -441,6 +454,20 @@
 		spi-max-frequency = <50000000>;
 		spi-rx-bus-width = <2>;
 		m25p,fast-read;
+		label = "pnor-2";
+		partitions@a0000000 {
+			compatible = "fixed-partitions";
+			#address-cells = <1>;
+			#size-cells = <1>;
+			pnor-primary@0 {
+				label = "pnor-2-primary";
+				reg = <0x0000000 0x2000000>;
+			};
+			pnor-scratch@2000000 {
+				label = "pnor-2-scratch";
+				reg = <0x2000000 0x2000000>;
+			};
+		};
 	};
 };
 


### PR DESCRIPTION
Split the primary and secondary BIOS SPI EEPROMs in 2 partitions

Signed-off-by: George Hung <george.hung@quantatw.com>