### PR TITLE
dts: nuvoton: npcm845-evb: add openbmc mctpd support

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -297,7 +297,7 @@
 			status = "disabled";
 		};
 
-		vdm: vdm@e0800000 {
+		vdma: vdma@e0800000 {
 			compatible = "nuvoton,npcm845-vdm";
 			reg = <0x0 0xe0800000 0x0 0x1000
 				   0x0 0xf0822000 0x0 0x1000>;

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
@@ -302,7 +302,7 @@
 			status = "okay";
 		};
 
-		vdm: vdm@e0800000 {
+		vdma: vdma@e0800000 {
 			status = "okay";
 		};
 


### PR DESCRIPTION
1. Modify the vdm sysfs path

Signed-off-by: kfting <kfting@nuvoton.com>