### PR TITLE
misc: npcm7xx-mcu-flash: change default pin configuration

### DIFF
--- a/drivers/misc/npcm7xx-mcu-flash.c
+++ b/drivers/misc/npcm7xx-mcu-flash.c
@@ -475,7 +475,7 @@ static int npcm7xx_mcu_probe(struct platform_device *pdev)
 	int i, ret;
 
 	enum gpiod_flags pin_flags[PIN_TOTAL] = {
-		GPIOD_OUT_LOW, GPIOD_OUT_LOW, GPIOD_IN, GPIOD_OUT_HIGH,
+		GPIOD_OUT_HIGH, GPIOD_OUT_HIGH, GPIOD_IN, GPIOD_OUT_HIGH,
 	};
 
 	dev_info(&pdev->dev, "%s", __func__);


### PR DESCRIPTION
Issue symptom:
When doing i2c bus stress test with cross write i2c bus pin,
then got failed message as below then cause stress test failed.
kernel: nuvoton-i2c f0083000.i2c: I2C3 init fail: lines are low
kernel: nuvoton-i2c f0083000.i2c: SDA=0 SCL=0
kernel: nuvoton-i2c f0083000.i2c: npcm_i2c_init_module failed

Root cause:
Due to our i2c driver design that will check SCL and SDA signal must NOT low.
If not, i2c driver will report probe fail. However, our mcu flash driver
programming mode pin is share with i2c bus pin in normal mode.
And default these pin value are configured as low in mcu driver.
Thus, this conflict will casue this issue when doing cross write i2c stress test.

Solution:
Change default pin configuration to high to avoid conflict with i2c driver design.

Verified:
Run loadmcu to flash MCU F/W and check F/W verion.
Check log there is no more i2c init fail message with cross write i2c bus pin in BUV and Arbel.

Signed-off-by: Tim Lee <timlee660101@gmail.com>