### PR TITLE
Fix truncated WrEndPointConfig MMIO command

### DIFF
--- a/drivers/peci/peci-core.c
+++ b/drivers/peci/peci-core.c
@@ -1037,7 +1037,6 @@ static int peci_cmd_wr_end_pt_cfg(struct peci_adapter *adapter, void *vmsg)
 				       >> 24); /* MSB - DWORD Register Offset */
 		if (umsg->params.mmio.addr_type ==
 		    PECI_ENDPTCFG_ADDR_TYPE_MMIO_Q) {
-			msg->tx_len = PECI_WRENDPTCFG_MMIO_Q_WRITE_LEN_BASE;
 			msg->tx_buf[14] = (u8)(umsg->params.mmio.offset
 					       >> 32); /* Register Offset */
 			msg->tx_buf[15] = (u8)(umsg->params.mmio.offset


### PR DESCRIPTION
When address type is 6, the driver is reducing the msg buffer to
the base size and truncating the additional command data.

This removes the line that sets the msg buffer size to the base
size.  The correct buffer size is already set.

Tested:
Ran this command:
peci_cmds WrEndpointConfigMMIO 6 0 0 0x7e 0x1a 0x0 0x224e0 0x5f5a56

and got the full buffer in the driver log:
[  795.207278] peci_aspeed 1e78b000.peci-bus: HEAD : 0x00011730
[  795.212980] TX : c5 00 05 00 00 00 06 00 d0 7e e0 24 02 00 00 00  .........~.$....
[  795.220556] TX : 00 00 56 5a 5f 00 a8                             ..VZ_..

Signed-off-by: Jason M. Bills <jason.m.bills@linux.intel.com>