### PR TITLE
arm: dts: Add missing Makefile line for buv-runbmc

### DIFF
--- a/arch/arm/boot/dts/Makefile
+++ b/arch/arm/boot/dts/Makefile
@@ -345,7 +345,8 @@ dtb-$(CONFIG_ARCH_NPCM7XX) += \
 	nuvoton-npcm730-gsz.dtb \
 	nuvoton-npcm730-kudo.dtb \
 	nuvoton-npcm750-evb.dtb \
-	nuvoton-npcm750-runbmc-olympus.dtb
+	nuvoton-npcm750-runbmc-olympus.dtb \
+	nuvoton-npcm750-buv-runbmc.dtb
 dtb-$(CONFIG_MACH_MESON6) += \
 	meson6-atv1200.dtb
 dtb-$(CONFIG_MACH_MESON8) += \


### PR DESCRIPTION
This lets the .dtb rebuild automatically