### PR TITLE
dts: aes: disable DMA for AES driver temporary

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -238,8 +238,7 @@
 
 		aes: aes@f0858000 {
 			compatible = "nuvoton,npcm845-aes";
-			reg = <0x0 0xf0858000 0x0 0x1000>,
-			<0x0 0xf0851000 0x0 0x1000>;
+			reg = <0x0 0xf0858000 0x0 0x1000>;
 			status = "disabled";
 			clocks = <&clk NPCM8XX_CLK_AHB>;
 			clock-names = "clk_ahb";


### PR DESCRIPTION
Signed-off-by: Tim Lee <timlee660101@gmail.com>