### PR TITLE
driver: net: phy: fix MDI-X unknown status of ethtool

### DIFF
--- a/drivers/net/phy/broadcom.c
+++ b/drivers/net/phy/broadcom.c
@@ -26,6 +26,20 @@ MODULE_DESCRIPTION("Broadcom PHY driver");
 MODULE_AUTHOR("Maciej W. Rozycki");
 MODULE_LICENSE("GPL");
 
+static int bcm54xx_read_mdix(struct phy_device *phydev)
+{
+	int reg;
+
+	reg = phy_read(phydev, MII_BCM54XX_ESR);
+
+	if (reg & MII_BCM54XX_ESR_MDIX)
+		phydev->mdix = ETH_TP_MDI_X;
+	else
+		phydev->mdix = ETH_TP_MDI;
+
+	return 0;
+}
+
 static int bcm54xx_config_clock_delay(struct phy_device *phydev)
 {
 	int rc, val;
@@ -72,6 +86,9 @@ static int bcm54210e_config_init(struct phy_device *phydev)
 	int val;
 
 	bcm54xx_config_clock_delay(phydev);
+
+	/* Read MDI Crossover State */
+	bcm54xx_read_mdix(phydev);
 
 	if (phydev->dev_flags & PHY_BRCM_EN_MASTER_MODE) {
 		val = phy_read(phydev, MII_CTRL1000);

--- a/include/linux/brcmphy.h
+++ b/include/linux/brcmphy.h
@@ -87,6 +87,7 @@
 
 #define MII_BCM54XX_ESR		0x11	/* BCM54xx extended status register */
 #define MII_BCM54XX_ESR_IS	0x1000	/* Interrupt status */
+#define MII_BCM54XX_ESR_MDIX	0x2000	/* MDI Crossover status */
 
 #define MII_BCM54XX_EXP_DATA	0x15	/* Expansion register data */
 #define MII_BCM54XX_EXP_SEL	0x17	/* Expansion register select */


### PR DESCRIPTION
Root cause:
In Arbel, ethernet is using BCM54210E phy driver.
Due to this phy driver didn’t implement read MDI-X state functionality.
Thus, cause ethtool get 0 value then MDI-X field show "Unknown" status.

Solution:
According BCM54210E phy spec, there is PHY Extended Status Register.
Thus, we implement bcm54xx_read_mdix() function to read MDI-X status
when doing phy initialization in bcm54210e_config_init() function.

Tested:
root@evb-npcm845:~# ethtool eth1
MDI-X: off

Signed-off-by: Tim Lee <timlee660101@gmail.com>