### PR TITLE
dts: Reduce reserved video memory from 32M to 24M

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
@@ -66,7 +66,7 @@
 
 		video_memory: framebuffer@0x1b000000 {
 			compatible = "shared-dma-pool";
-			reg = <0x1b000000 0x02000000>;
+			reg = <0x1b000000 0x01800000>;
 			reusable;
 			linux,cma-default;
 		};

--- a/arch/arm/boot/dts/nuvoton-npcm750-evb.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-evb.dts
@@ -71,7 +71,7 @@
 
 		video_memory: framebuffer@0x1b000000 {
 			compatible = "shared-dma-pool";
-			reg = <0x1b000000 0x02000000>;
+			reg = <0x1b000000 0x01800000>;
 			reusable;
 			linux,cma-default;
 		};

--- a/arch/arm/boot/dts/nuvoton-npcm750-runbmc-olympus.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-runbmc-olympus.dts
@@ -66,7 +66,7 @@
 
 		video_memory: framebuffer@0x1b000000 {
 			compatible = "shared-dma-pool";
-			reg = <0x1b000000 0x02000000>;
+			reg = <0x1b000000 0x01800000>;
 			reusable;
 			linux,cma-default;
 		};

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
@@ -86,7 +86,7 @@
 
 		video_memory: framebuffer@0x33000000 {
 			compatible = "shared-dma-pool";
-			reg = <0x0 0x33000000 0x0 0x02000000>;
+			reg = <0x0 0x33000000 0x0 0x01800000>;
 			reusable;
 			linux,cma-default;
 		};


### PR DESCRIPTION
Reduce reserved video memory from 32M to 24M.

Usage:
  V4L2 buffers: 5M * 3
  VCD frame buffer: 5M

cat /proc/meminfo:
  CmaTotal: 24576 kB
  CmaFree: 3648 kB