### PR TITLE
dts: buv-runbmc: spi: fix spix pin group does not be set and enable s…

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
@@ -226,15 +226,18 @@
 
 &fiux {
 	pinctrl-0 = <&spix_pins>;
+	pinctrl-names = "default";
 	status = "okay";
-	spix-mode;
+	reg = <0xfb001000 0x1000>, <0xf8000000 0x2000000>;
+	reg-names = "control", "memory";
 	spi-nor@0 {
 		compatible = "m25p80-nonjedec";
 		spi-max-frequency = <5000000>;
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <0>;
-		spi-rx-bus-width = <1>;
+		spi-rx-bus-width = <2>;
+		spi-tx-bus-width = <2>;
 
 		partitions@F8000000 {
 			compatible = "fixed-partitions";


### PR DESCRIPTION
…pix dual mode

Add spix pinctrl-names for pinctrl driver to set spix pin group.
Enable spix dual mode.

boot logs:
spi-nor spi4.0: m25p80-nonjedec (1024 Kbytes)
1 fixed-partitions partitions found on MTD device spi4.0
Creating 1 MTD partitions on "spi4.0":
0x000000000000-0x000002000000 : "xbios"
mtd: partition "xbios" extends beyond the end of device "spi4.0" -- size truncated to 0x100000

Signed-off-by: jhkang <jhkang@nuvoton.com>