### PR TITLE
Revert "dts: npcm845-evb: Move video memory to 0x33400000"

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
@@ -84,9 +84,9 @@
 		#size-cells = <2>;
 		ranges;
 
-		video_memory: framebuffer@0x33400000 {
+		video_memory: framebuffer@0x33000000 {
 			compatible = "shared-dma-pool";
-			reg = <0x0 0x33400000 0x0 0x01800000>;
+			reg = <0x0 0x33000000 0x0 0x01800000>;
 			reusable;
 			linux,cma-default;
 		};


### PR DESCRIPTION
This reverts commit 3030ee779ca428b042d08ad17bb8a89d09da63b2.

u-boot will reserve the memory in advance. Set to 0x33400000 will overlap
with another area that is reserved in u-boot and print an error log (it
won't impact the functionality though).