### PR TITLE
dts: npcm: add pci-rc node

### DIFF
--- a/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
@@ -273,6 +273,21 @@
 			status = "disabled";
 		};
 
+		pci_rc: pcie@e1000000 {
+			#address-cells = <3>;
+			#size-cells = <2>;
+			#interrupt-cells = <1>;
+			compatible = "nuvoton,npcm750-pcirc";
+			reg = <0xe1000000 0x1000>;
+			device_type = "pci";
+			interrupts = <GIC_SPI 127 IRQ_TYPE_LEVEL_HIGH>;
+			bus-range = <0x00 0xff>;
+			ranges = <0x02000000 0 0xea000000
+				0xea000000 0 0x02000000>;
+			resets = <&rstc NPCM7XX_RESET_IPSRST3 NPCM7XX_RESET_PCIE_RC>;
+			status = "disabled";
+		};
+
 		dvc: dvc@f0808000 {
 			compatible = "nuvoton,npcm750-dvc";
 			reg = <0xf0808000 0x1000>;


### PR DESCRIPTION
Cherry-pick lost change from 5.4 (see https://github.com/Nuvoton-Israel/linux/commit/d63410b472dbd4b67b5ce56fa30572495d6322fa). This change is already present in the NPCM-5.10-OpenBMC branch.