### PR TITLE
dts: npcm845-evb: add simple-mfd support for gcr in dts

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -19,7 +19,8 @@
 		ranges;
 
 		gcr: system-controller@f0800000 {
-			compatible = "nuvoton,npcm845-gcr", "syscon";
+			compatible = "nuvoton,npcm845-gcr", "syscon",
+				"simple-mfd";
 			reg = <0x0 0xf0800000 0x0 0x1000>;
 		};
 


### PR DESCRIPTION
Signed-off-by: Tyrone Ting <kfting@nuvoton.com>