### PR TITLE
driver: gpio: nuvoton: modify sgpio driver and dts

### DIFF
--- a/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
@@ -505,32 +505,32 @@
 			};
 
 			sgpio1: sgpio@101000 {
-				clocks = <&clk NPCM7XX_CLK_APB3>;
 				compatible = "nuvoton,npcm750-sgpio";
+				reg = <0x101000 0x200>;
+				clocks = <&clk NPCM7XX_CLK_APB3>;
+				bus-frequency = <8000000>;
 				interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&iox1_pins>;
-				bus-frequency = <16000000>;
-				nin_gpios = <64>;
-				nout_gpios = <64>;
-				reg = <0x101000 0x200>;
+				nuvoton,input-ngpios = <64>;
+				nuvoton,output-ngpios = <64>;
 				status = "disabled";
 			};
 
 			sgpio2: sgpio@102000 {
-				clocks = <&clk NPCM7XX_CLK_APB3>;
 				compatible = "nuvoton,npcm750-sgpio";
+				reg = <0x102000 0x200>;
+				clocks = <&clk NPCM7XX_CLK_APB3>;
+				bus-frequency = <8000000>;
 				interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&iox2_pins>;
-				bus-frequency = <16000000>;
-				nin_gpios = <64>;
-				nout_gpios = <64>;
-				reg = <0x102000 0x200>;
+				nuvoton,input-ngpios = <64>;
+                                nuvoton,output-ngpios = <64>;
 				status = "disabled";
 			};
 

--- a/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-buv-runbmc.dts
@@ -128,9 +128,9 @@
 };
 
 &sgpio2 {
-	bus-frequency = <16000000>;
-	nin_gpios = <8>;
-	nout_gpios = <8>;
+	bus-frequency = <8000000>;
+	nuvoton,input-ngpios = <8>;
+	nuvoton,output-ngpios = <8>;
 	gpio-line-names="s1","s2","s3","s4","s5","s6","s7","s8";
 	status = "okay";
 };

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -578,32 +578,32 @@
 			};
 
 			sgpio1: sgpio@101000 {
-				clocks = <&clk NPCM8XX_CLK_APB3>;
 				compatible = "nuvoton,npcm845-sgpio";
+				reg = <0x101000 0x200>;
+				clocks = <&clk NPCM8XX_CLK_APB3>;
+				bus-frequency = <8000000>;
 				interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&iox1_pins>;
-				bus-frequency = <16000000>;
-				nin_gpios = <64>;
-				nout_gpios = <64>;
-				reg = <0x101000 0x200>;
+				nuvoton,input-ngpios = <64>;
+				nuvoton,output-ngpios = <64>;
 				status = "disabled";
 			};
 
 			sgpio2: sgpio@102000 {
-				clocks = <&clk NPCM8XX_CLK_APB3>;
 				compatible = "nuvoton,npcm845-sgpio";
+				reg = <0x102000 0x200>;
+				clocks = <&clk NPCM8XX_CLK_APB3>;
+				bus-frequency = <8000000>;
 				interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
 				gpio-controller;
 				#gpio-cells = <2>;
 				pinctrl-names = "default";
 				pinctrl-0 = <&iox2_pins>;
-				bus-frequency = <16000000>;
-				nin_gpios = <64>;
-				nout_gpios = <64>;
-				reg = <0x102000 0x200>;
+				nuvoton,input-ngpios = <64>;
+                                nuvoton,output-ngpios = <64>;
 				status = "disabled";
 			};
 


### PR DESCRIPTION
1. Add npcm_sgpio_init_port function replace init_valid_mask function to support dts gpio-hog method
2. Modify sgpio clk calculate method
3. modify dts property name and default clk