### PR TITLE
net: stmmac: Support NCSI VLAN filtering

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -6737,8 +6737,8 @@ static const struct net_device_ops stmmac_netdev_ops = {
 	.ndo_poll_controller = stmmac_poll_controller,
 #endif
 	.ndo_set_mac_address = stmmac_set_mac_address,
-	.ndo_vlan_rx_add_vid = stmmac_vlan_rx_add_vid,
-	.ndo_vlan_rx_kill_vid = stmmac_vlan_rx_kill_vid,
+	.ndo_vlan_rx_add_vid = ncsi_vlan_rx_add_vid,
+	.ndo_vlan_rx_kill_vid = ncsi_vlan_rx_kill_vid,
 	.ndo_bpf = stmmac_bpf,
 	.ndo_xdp_xmit = stmmac_xdp_xmit,
 	.ndo_xsk_wakeup = stmmac_xsk_wakeup,
@@ -7161,6 +7161,9 @@ int stmmac_dvr_probe(struct device *device,
 		priv->sph = priv->sph_cap;
 		dev_info(priv->device, "SPH feature enabled\n");
 	}
+
+	if (priv->plat->use_ncsi)
+		netdev->hw_features |= NETIF_F_HW_VLAN_CTAG_FILTER;
 
 	/* The current IP register MAC_HW_Feature1[ADDR64] only define
 	 * 32/40/64 bit width, but some SOC support others like i.MX8MP


### PR DESCRIPTION
Register ncsi_vlan_rx_add_vid and ncsi_vlan_rx_kill_vid callbacks and set the NETIF_F_HW_VLAN_CTAG_FILTER when NCSI is available.