### PR TITLE
net: stmmac: Support NCSI VLAN filtering

### DIFF
--- a/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
+++ b/drivers/net/ethernet/stmicro/stmmac/stmmac_main.c
@@ -4733,6 +4733,9 @@ static int stmmac_vlan_rx_add_vid(struct net_device *ndev, __be16 proto, u16 vid
 	bool is_double = false;
 	int ret;
 
+	if (priv->plat->use_ncsi)
+		return ncsi_vlan_rx_add_vid(ndev, proto, vid);
+
 	if (be16_to_cpu(proto) == ETH_P_8021AD)
 		is_double = true;
 
@@ -4757,6 +4760,9 @@ static int stmmac_vlan_rx_kill_vid(struct net_device *ndev, __be16 proto, u16 vi
 	struct stmmac_priv *priv = netdev_priv(ndev);
 	bool is_double = false;
 	int ret;
+
+	if (priv->plat->use_ncsi)
+		return ncsi_vlan_rx_kill_vid(ndev, proto, vid);
 
 	ret = pm_runtime_get_sync(priv->device);
 	if (ret < 0) {
@@ -5122,6 +5128,9 @@ int stmmac_dvr_probe(struct device *device,
 		priv->sph = true;
 		dev_info(priv->device, "SPH feature enabled\n");
 	}
+
+	if (priv->plat->use_ncsi)
+		netdev->hw_features |= NETIF_F_HW_VLAN_CTAG_FILTER;
 
 	/* The current IP register MAC_HW_Feature1[ADDR64] only define
 	 * 32/40/64 bit width, but some SOC support others like i.MX8MP


### PR DESCRIPTION
Register ncsi_vlan_rx_add_vid and ncsi_vlan_rx_kill_vid callbacks and set the NETIF_F_HW_VLAN_CTAG_FILTER when NCSI is available.