### PR TITLE
iio: adc: nct720x: Read correct MNTVIN Low byte value

### DIFF
--- a/drivers/iio/adc/nct720x.c
+++ b/drivers/iio/adc/nct720x.c
@@ -204,7 +204,7 @@ static int nct720x_read_raw(struct iio_dev *indio_dev,
 			goto abort;
 		}
 
-		v2 = nct720x_read_reg(chip, REG_VIN[index]);
+		v2 = nct720x_read_reg(chip, REG_VOLT_LOW_BYTE);
 		if (v2 < 0) {
 			err = v2;
 			goto abort;


### PR DESCRIPTION
Signed-off-by: Eason Yang <yhyang2@nuvoton.com>