### PR TITLE
drivers: spi: fix programming NPCM_FIU_UMA_CFG

### DIFF
--- a/drivers/spi/spi-npcm-fiu.c
+++ b/drivers/spi/spi-npcm-fiu.c
@@ -353,8 +353,13 @@ static int npcm_fiu_uma_read(struct spi_mem *mem,
 		uma_cfg |= ilog2(op->cmd.buswidth);
 		uma_cfg |= ilog2(op->addr.buswidth)
 			<< NPCM_FIU_UMA_CFG_ADBPCK_SHIFT;
-		uma_cfg |= ilog2(op->dummy.buswidth)
+
+		// To fix dummy.buswidth is zero bug
+		if (op->dummy.buswidth != 0){
+			uma_cfg |= ilog2(op->dummy.buswidth)
 			<< NPCM_FIU_UMA_CFG_DBPCK_SHIFT;
+		}
+
 		uma_cfg |= ilog2(op->data.buswidth)
 			<< NPCM_FIU_UMA_CFG_RDBPCK_SHIFT;
 		uma_cfg |= op->dummy.nbytes << NPCM_FIU_UMA_CFG_DBSIZ_SHIFT;


### PR DESCRIPTION
This cherry-picks https://github.com/Nuvoton-Israel/openbmc/blob/npcm-master/meta-evb/meta-evb-nuvoton/meta-buv-runbmc/recipes-kernel/linux/linux-nuvoton/0001-drivers-spi-Bugfixed-npcm_fiu_uma_read-set-wrong-val.patch to avoid crashes when enabling UMA.