### PR TITLE
ARM: dts: npcm7xx: Remove direct read mapping in FIU

### DIFF
--- a/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
@@ -248,7 +248,7 @@
 			compatible = "nuvoton,npcm750-fiu";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0xfb000000 0x1000>, <0x80000000 0x10000000>;
+			reg = <0xfb000000 0x1000>;
 			reg-names = "control", "memory";
 			clocks = <&clk NPCM7XX_CLK_AHB>;
 			clock-names = "clk_ahb";
@@ -259,7 +259,7 @@
 			compatible = "nuvoton,npcm750-fiu";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0xc0000000 0x1000>, <0xA0000000 0x20000000>;
+			reg = <0xc0000000 0x1000>;
 			reg-names = "control", "memory";
 			clocks = <&clk NPCM7XX_CLK_SPI3>;
 			clock-names = "clk_spi3";
@@ -272,7 +272,7 @@
 			compatible = "nuvoton,npcm750-fiu";
 			#address-cells = <1>;
 			#size-cells = <0>;
-			reg = <0xfb001000 0x1000>, <0xf8000000 0x2000000>;
+			reg = <0xfb001000 0x1000>;
 			reg-names = "control", "memory";
 			clocks = <&clk NPCM7XX_CLK_AHB>;
 			clock-names = "clk_ahb";


### PR DESCRIPTION
This cherry-picks https://github.com/openbmc/linux/commit/59bffc94574f7541ad3dcbac3586812464c841a7 to disable Direct Read.