### PR TITLE
i2c-npcm7xx.c: Enable slave in eob interrupt

### DIFF
--- a/drivers/i2c/busses/i2c-npcm7xx.c
+++ b/drivers/i2c/busses/i2c-npcm7xx.c
@@ -1787,6 +1787,12 @@ static int npcm_i2c_int_master_handler(struct npcm_i2c *bus)
 	    (FIELD_GET(NPCM_I2CCST3_EO_BUSY,
 		       ioread8(bus->reg + NPCM_I2CCST3)))) {
 		npcm_i2c_irq_handle_eob(bus);
+#if IS_ENABLED(CONFIG_I2C_SLAVE)
+		/* reenable slave if it was enabled */
+		if (bus->slave)
+			iowrite8((bus->slave->addr & 0x7F) | NPCM_I2CADDR_SAEN,
+				bus->reg + NPCM_I2CADDR1);
+#endif
 		return 0;
 	}
 


### PR DESCRIPTION
Nuvoton slave enable was in user space API call master_xfer, so it is subject to delays from the OS scheduler. If the BMC is not enabled for slave mode in time for master to send response, then it will NAK the address match. Then the PLDM request timeout occurs.

If the slave enable is moved to the EOB interrupt service routine, then the BMC can be ready in slave mode by the time it needs to receive a response.