### PR TITLE
arm: dts: evb-npcm750: Update pin24/25 pins value and remove udc9

### DIFF
--- a/arch/arm/boot/dts/nuvoton-npcm750-evb.dts
+++ b/arch/arm/boot/dts/nuvoton-npcm750-evb.dts
@@ -29,7 +29,7 @@
 		udc6 = &udc6;
 		udc7 = &udc7;
 		udc8 = &udc8;
-		udc9 = &udc9;
+		/* udc9 = &udc9; */
 		emmc0 = &sdhci0;
 		emmc1 = &sdhci1;
 		i2c0 = &i2c0;
@@ -172,9 +172,10 @@
 	status = "okay";
 };
 
-&udc9 {
+/* using USB host instead of UDC9*/
+/* &udc9 {
 	status = "okay";
-};
+}; */
 
 &aes {
 	status = "okay";

--- a/arch/arm/boot/dts/nuvoton-npcm750-pincfg-evb.dtsi
+++ b/arch/arm/boot/dts/nuvoton-npcm750-pincfg-evb.dtsi
@@ -29,12 +29,12 @@
 			input-enable;
 		};
 		pin24_output_high: pin24-output-high {
-			pins = "GPIO24/IOXHDO";
+			pins = "GPIO24/HGPIO4/IOXHDO";
 			bias-disable;
 			output-high;
 		};
 		pin25_output_low: pin25-output-low {
-			pins = "GPIO25/IOXHDI";
+			pins = "GPIO25/HGPIO5/IOXHDI";
 			bias-disable;
 			output-low;
 		};


### PR DESCRIPTION
1. Update pin24/25 pins value to match npcm7xx pinctrl driver.
2. Remove udc9 to enable usb host function.