### PR TITLE
arm64: dts: npcm8xx: remove wrong compatible

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -425,7 +425,7 @@
 			};
 
 			watchdog0: watchdog@801c {
-				compatible = "nuvoton,npcm845-wdt", "nuvoton,npcm750-wdt";
+				compatible = "nuvoton,npcm845-wdt";
 				interrupts = <GIC_SPI 47 IRQ_TYPE_LEVEL_HIGH>;
 				reg = <0x801c 0x4>;
 				status = "disabled";
@@ -434,7 +434,7 @@
 			};
 
 			watchdog1: watchdog@901c {
-				compatible = "nuvoton,npcm845-wdt", "nuvoton,npcm750-wdt";
+				compatible = "nuvoton,npcm845-wdt";
 				interrupts = <GIC_SPI 48 IRQ_TYPE_LEVEL_HIGH>;
 				reg = <0x901c 0x4>;
 				status = "disabled";
@@ -443,7 +443,7 @@
 			};
 
 			watchdog2: watchdog@a01c {
-				compatible = "nuvoton,npcm845-wdt", "nuvoton,npcm750-wdt";
+				compatible = "nuvoton,npcm845-wdt";
 				interrupts = <GIC_SPI 49 IRQ_TYPE_LEVEL_HIGH>;
 				reg = <0xa01c 0x4>;
 				status = "disabled";


### PR DESCRIPTION
get reset reson will check if device is npcm7xx or nmcp8xx. remove wrong compatible for fix get reset reson error