### PR TITLE
media: nuvoton: Add HSYNC mode support

### DIFF
--- a/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
@@ -299,6 +299,7 @@
 			nuvoton,sysgcr = <&gcr>;
 			nuvoton,sysgfxi = <&gfxi>;
 			nuvoton,ece = <&ece>;
+			nuvoton,de-mode;
 			status = "disabled";
 		};
 

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -333,6 +333,7 @@
 			nuvoton,sysgcr = <&gcr>;
 			nuvoton,sysgfxi = <&gfxi>;
 			nuvoton,ece = <&ece>;
+			nuvoton,de-mode;
 			status = "disabled";
 		};
 

--- a/drivers/media/platform/nuvoton/npcm-regs.h
+++ b/drivers/media/platform/nuvoton/npcm-regs.h
@@ -21,10 +21,15 @@
 #define  VCD_CAP_RES_VERT_RES		GENMASK(10, 0)
 #define  VCD_CAP_RES_HOR_RES		GENMASK(26, 16)
 
+#define VCD_DVO_DEL			0x8010
+#define  VCD_DVO_DEL_HSYNC_DEL		GENMASK(10, 0)
+#define  VCD_DVO_DEL_VSYNC_DEL		GENMASK(26, 16)
+
 #define VCD_MODE			0x8014
 #define  VCD_MODE_VCDE			BIT(0)
 #define  VCD_MODE_CM565			BIT(1)
 #define  VCD_MODE_IDBC			BIT(3)
+#define  VCD_MODE_DE_HS			BIT(11)
 #define  VCD_MODE_KVM_BW_SET		BIT(16)
 
 #define VCD_CMD				0x8018
@@ -71,7 +76,7 @@
 
 #define VCD_MAX_SRC_BUFFER_SIZE		0x500000 /* 1920 x 1200 x 2 bpp */
 #define VCD_KVM_BW_PCLK			120000000UL
-#define VCD_BUSY_TIMEOUT_US		300000
+#define VCD_TIMEOUT_US			300000
 
 /* ECE Registers */
 #define ECE_DDA_CTRL			0x0000
@@ -148,9 +153,6 @@
 
 #define GMMAP_LENGTH			0xc00000 /* 4MB preserved, total 16MB */
 
-#define MFSEL1				0x0c
-#define  MFSEL1_DVH1SEL			BIT(27)
-
 /* GFXI Register */
 #define DISPST				0x00
 #define  DISPST_HSCROFF			BIT(1)
@@ -162,11 +164,23 @@
 #define HVCNTH				0x14
 #define  HVCNTH_MASK			GENMASK(2, 0)
 
+#define HBPCNTL				0x18
+#define  HBPCNTL_MASK			GENMASK(7, 0)
+
+#define HBPCNTH				0x1c
+#define  HBPCNTH_MASK			BIT(0)
+
 #define VVCNTL				0x20
 #define  VVCNTL_MASK			GENMASK(7, 0)
 
 #define VVCNTH				0x24
 #define  VVCNTH_MASK			GENMASK(2, 0)
+
+#define VBPCNTL				0x28
+#define  VBPCNTL_MASK			GENMASK(7, 0)
+
+#define VBPCNTH				0x2c
+#define  VBPCNTH_MASK			BIT(0)
 
 #define GPLLINDIV			0x40
 #define  GPLLINDIV_MASK			GENMASK(5, 0)


### PR DESCRIPTION
Driver will use DE mode by default. To enable HSYNC mode, just remove "nuvoton,de-mode" property of VCD node in DT.