### PR TITLE
media: nuvoton: Add HSYNC mode option

### DIFF
--- a/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton-common-npcm7xx.dtsi
@@ -299,7 +299,6 @@
 			nuvoton,sysgcr = <&gcr>;
 			nuvoton,sysgfxi = <&gfxi>;
 			nuvoton,ece = <&ece>;
-			nuvoton,de-mode;
 			status = "disabled";
 		};
 

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -333,7 +333,6 @@
 			nuvoton,sysgcr = <&gcr>;
 			nuvoton,sysgfxi = <&gfxi>;
 			nuvoton,ece = <&ece>;
-			nuvoton,de-mode;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
Driver doesn't check "nuvoton,de-mode" property any more. To enable HSYNC mode, just add "nuvoton,hsync-mode" property of VCD node in DT.