### PR TITLE
rtc: nuvoton: Compatible with NCT3015Y-R and NCT3018Y-R

### DIFF
--- a/Documentation/devicetree/bindings/rtc/nuvoton,nct3018y.yaml
+++ b/Documentation/devicetree/bindings/rtc/nuvoton,nct3018y.yaml
@@ -15,7 +15,9 @@ maintainers:
 
 properties:
   compatible:
-    const: nuvoton,nct3018y
+    enum:
+      - nuvoton,nct3018y
+      - nuvoton,nct3015y
 
   reg:
     maxItems: 1


### PR DESCRIPTION
- In probe,
   If part number is NCT3018Y-R, only set HF bit to 24-Hour format.
   Else, do nothing
- In set_time,
   If part number is NCT3018Y-R && TWO bit is 0,
      change TWO bit to 1, and restore TWO bit after updating time.
- Use DT compatible to check the chip matches or not.