### PR TITLE
i3c: hub: Configure Open-Drain/Push-Pull mode for slave port

### DIFF
--- a/drivers/i3c/i3c-hub.c
+++ b/drivers/i3c/i3c-hub.c
@@ -492,6 +492,11 @@ static int i3c_hub_hw_configure_tp(struct device *dev)
 	if (ret)
 		return ret;
 
+	/* Set Open-Drain / Push-Pull compatible for I3C mode */
+	ret = regmap_update_bits(priv->regmap, I3C_HUB_TP_IO_MODE_CONF, i3c_mask, ~i3c_val);
+	if (ret)
+		return ret;
+
 	ret = regmap_update_bits(priv->regmap, I3C_HUB_TP_SMBUS_AGNT_EN, smbus_mask, smbus_val);
 	if (ret)
 		return ret;


### PR DESCRIPTION
Configure Open-Drain/Push-Pull mode for slave port.