### PR TITLE
drivers: net: ethernet: fix bugs which might cause kernel panic in np…

### DIFF
--- a/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
+++ b/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
@@ -1933,9 +1933,7 @@ static int npcm7xx_mii_setup(struct net_device *netdev)
 out3:
 	mdiobus_unregister(ether->mii_bus);
 out2:
-	kfree(ether->mii_bus->irq);
 	mdiobus_free(ether->mii_bus);
-	platform_set_drvdata(ether->pdev, NULL);
 out0:
 	return err;
 }
@@ -2109,7 +2107,6 @@ failed_free_napi:
 	if (of_phy_is_fixed_link(np))
 		of_phy_deregister_fixed_link(np);
 	netif_napi_del(&ether->napi);
-	platform_set_drvdata(pdev, NULL);
 failed_free_io:
 	iounmap(ether->reg);
 failed_free_mem:


### PR DESCRIPTION
…cm7xx_emc.c

Remove set NULL in platform_set_drvdata(), it might cause "Unable to handle kernel NULL pointer" kernel panic.

Remove kfree(ether->mii_bus->irq), since mdiobus_free(ether->mii_bus) already free memory. This line will cause "Unable to handle kernel NULL pointer" kernel panic, too.

Reproduce issue methond:
echo f0825000.eth > /sys/bus/platform/drivers/npcm7xx-emc/bind echo f0825000.eth > /sys/bus/platform/drivers/npcm7xx-emc/unbind