### PR TITLE
drivers: net: ethernet: fix bugs which might cause kernel panic in np…

### DIFF
--- a/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
+++ b/drivers/net/ethernet/nuvoton/npcm7xx_emc.c
@@ -1889,8 +1889,6 @@ static int npcm7xx_mii_setup(struct net_device *netdev)
 	for (i = 0; i < PHY_MAX_ADDR; i++)
 		ether->mii_bus->irq[i] = PHY_POLL;
 
-	platform_set_drvdata(ether->pdev, ether->mii_bus);
-
 	/* Enable MDIO Clock */
 	writel(readl((ether->reg + REG_MCMDR)) | MCMDR_ENMDC,
 	       (ether->reg + REG_MCMDR));
@@ -2134,14 +2132,11 @@ static int npcm7xx_ether_remove(struct platform_device *pdev)
 	if (of_phy_is_fixed_link(np))
 		of_phy_deregister_fixed_link(np);
 
-	free_irq(ether->txirq, netdev);
-	free_irq(ether->rxirq, netdev);
-
 	if (ether->phy_dev)
 		phy_disconnect(ether->phy_dev);
 
 	mdiobus_unregister(ether->mii_bus);
-	kfree(ether->mii_bus->irq);
+
 	mdiobus_free(ether->mii_bus);
 
 	platform_set_drvdata(pdev, NULL);


### PR DESCRIPTION
…cm7xx_emc.c if PHY on board

Remove platform_set_drvdata(ether->pdev, ether->mii_bus); It would cause driver getting wrong netdev pointer in npcm7xx_ether_remove() and caused all pointers getting NULL pointer in npcm7xx_ether_remove(). Then cause kernel panic.

Test done: (buv-runbmc board)
echo f0825000.eth > /sys/bus/platform/drivers/npcm7xx-emc/bind echo f0825000.eth > /sys/bus/platform/drivers/npcm7xx-emc/unbind