### PR TITLE
arm64: Set ARCH_NR_GPIO to 1024 for ARCH_NPCM

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -1897,6 +1897,18 @@ config STACKPROTECTOR_PER_TASK
 	def_bool y
 	depends on STACKPROTECTOR && CC_HAVE_STACKPROTECTOR_SYSREG
 
+# The GPIO number here must be sorted by descending number. In case of
+# a multiplatform kernel, we just want the highest value required by the
+# selected platforms.
+config ARCH_NR_GPIO
+        int
+        default 1024 if ARCH_NPCM
+        default 0
+        help
+          Maximum number of GPIOs in the system.
+
+          If unsure, leave the default value.
+
 endmenu
 
 menu "Boot options"


### PR DESCRIPTION
Increase the max number of GPIOs from default 512 to 1024 for NPCM platforms, because total GPIO pins exceed 512 if vwgpio is involved.