### PR TITLE
arm64: Set ARCH_NR_GPIO to 1024 for ARCH_NPCM

### DIFF
--- a/arch/arm64/Kconfig
+++ b/arch/arm64/Kconfig
@@ -2151,6 +2151,7 @@ config STACKPROTECTOR_PER_TASK
 config ARCH_NR_GPIO
         int
         default 2048 if ARCH_APPLE
+        default 1024 if ARCH_NPCM
         default 0
         help
           Maximum number of GPIOs in the system.


### PR DESCRIPTION
Increase the max number of GPIOs from default 512 to 1024 for NPCM platforms, because total GPIO pins exceed 512 if vwgpio is involved.