### PR TITLE
peci: npcm: fix npcm_peci_irq_handler panic

### DIFF
--- a/drivers/peci/controller/peci-npcm.c
+++ b/drivers/peci/controller/peci-npcm.c
@@ -337,6 +337,13 @@ static int npcm_peci_probe(struct platform_device *pdev)
 		return ret;
 	}
 
+	/* Clear status */
+	regmap_write_bits(priv->regmap, NPCM_PECI_CTL_STS,
+			  NPCM_PECI_INT_MASK, NPCM_PECI_INT_MASK);
+	/* Disable PECI interrupt */
+	regmap_update_bits(priv->regmap, NPCM_PECI_CTL_STS,
+			   NPCM_PECI_CTRL_DONE_INT_EN,
+			   0);
 	ret = devm_request_irq(&pdev->dev, priv->irq, npcm_peci_irq_handler,
 			       0, "peci-npcm-irq", priv);
 	if (ret)


### PR DESCRIPTION
Clear interrupt status and disable the interrupt before registering the irq handler