### PR TITLE
dt-bindings: gpio: Add bindings for NPCM vwgpio

### DIFF
--- a/Documentation/devicetree/bindings/soc/nuvoton/nuvoton,vwgpio.yaml
+++ b/Documentation/devicetree/bindings/soc/nuvoton/nuvoton,vwgpio.yaml
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/soc/nuvoton/nuvoton,vwgpio.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Nuvoton ESPI VWGPIO controller
+
+maintainers:
+  - Tomer Maimon <Tomer.Maimon@nuvoton.com>
+  - Ban Feng <kcfeng0@nuvoton.com>
+  - Stanley Chu <yschu@nuvoton.com>
+
+description:
+  The NPCM8xx supports the Intel Enhanced Serial Peripheral Interface (eSPI) Revision 1.0.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - nuvoton,npcm845-espi
+      - const: simple-mfd
+      - const: syscon
+
+  reg:
+    maxItems: 1
+
+patternProperties:
+  "^vw_gpio@[0-9a-f]+$":
+    type: object
+    additionalProperties: false
+
+    description: |
+      This VWGPIO controller is for NUVOTON NPCM8xx SoC, NPCM8xx has one
+      vwgpio module can support up to 64 output pins (VWGPSM0-15), and
+      up to 64 input pins (VWGPMS0-15), in this order.
+      VWGPIO pins can be programmed to support interrupt option for each
+      input port and various interrupt sensitivity option (level-high,
+      level-low, edge-high, edge-low)
+
+    properties:
+      compatible:
+        items:
+          - enum:
+              - nuvoton,npcm845-espi-vwgpio
+
+      interrupts:
+        maxItems: 1
+
+      gpio-controller: true
+
+      '#gpio-cells':
+        const: 2
+
+      nuvoton,gpio-control-map:
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2, 3]
+        default: 0
+        description: |
+          Controls the mapping of all the GPIO Virtual Wires (VWGPSM0-15,
+          VWGPMS0-15, in this order) to indices as follows
+            0: 80-111 (50h-6Fh) (default)
+            1: 128-159 (80h-9Fh)
+            2: 160-191 (A0h-BFh)
+            3: 192-223 (C0h-DFh)
+
+      nuvoton,control-interrupt-map:
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2, 3]
+        default: 0
+        description: |
+          Controls the mapping of interrupts 15-0 (in this order) originating
+          from the device modules to the reported IRQ lines of the Host.
+            0: 15-0 (default)
+            1: 31-16
+            2: 47-32
+            3: 63-48
+
+      nuvoton,index-en-map:
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 0x0
+        maximum: 0xFFFFFFFF
+        default: 0x0
+        description: |
+          Defines the index of the Virtual Wire group (VWGPMS15-0, VWGPSM15-0,
+          in this order)
+
+    required:
+      - compatible
+      - interrupts
+      - gpio-controller
+      - '#gpio-cells'
+      - nuvoton,gpio-control-map
+      - nuvoton,control-interrupt-map
+      - nuvoton,index-en-map
+
+required:
+  - compatible
+  - reg
+
+additionalProperties:
+  type: object
+
+examples:
+  - |
+    #include <dt-bindings/interrupt-controller/arm-gic.h>
+
+    espi: espi@9f000 {
+        compatible = "nuvoton,npcm845-espi", "simple-mfd", "syscon";
+        reg = <0x9F000 0x1000>;
+
+        vw_gpio: vw_gpio {
+            compatible = "nuvoton,npcm845-espi-vwgpio";
+            interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
+            gpio-controller;
+            #gpio-cells = <2>;
+            nuvoton,gpio-control-map = <1>;
+            nuvoton,control-interrupt-map = <0>;
+            nuvoton,index-en-map = <0x80000000>;
+        };
+    };

--- a/drivers/soc/nuvoton/npcm-espi-vwgpio.c
+++ b/drivers/soc/nuvoton/npcm-espi-vwgpio.c
@@ -392,11 +392,11 @@ static int npcm_vwgpio_probe(struct platform_device *pdev)
 
 	vwgpio->dev = dev;
 
-	if (of_property_read_u32(pdev->dev.of_node, "npcm,gpio-control-map", &gpvwmap))
+	if (of_property_read_u32(pdev->dev.of_node, "nuvoton,gpio-control-map", &gpvwmap))
 		gpvwmap = 0;
-	if (of_property_read_u32(pdev->dev.of_node, "npcm,control-interrupt-map", &intwin))
+	if (of_property_read_u32(pdev->dev.of_node, "nuvoton,control-interrupt-map", &intwin))
 		intwin = 0;
-	if (of_property_read_u32(pdev->dev.of_node, "npcm,index-en-map", &idxenmap))
+	if (of_property_read_u32(pdev->dev.of_node, "nuvoton,index-en-map", &idxenmap))
 		idxenmap = 0;
 
 	npcm_vwgpio_config(vwgpio, intwin, gpvwmap, idxenmap);


### PR DESCRIPTION
Add device tree bindings for the vwgpio NPCM.