### PR TITLE
npcm8xx: re-organize espi virtual wire gpio driver and add document

### DIFF
--- a/Documentation/devicetree/bindings/soc/nuvoton/nuvoton,vwgpio.yaml
+++ b/Documentation/devicetree/bindings/soc/nuvoton/nuvoton,vwgpio.yaml
@@ -1,0 +1,121 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/soc/nuvoton/nuvoton,vwgpio.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Nuvoton ESPI VWGPIO controller
+
+maintainers:
+  - Tomer Maimon <Tomer.Maimon@nuvoton.com>
+  - Ban Feng <kcfeng0@nuvoton.com>
+  - Stanley Chu <yschu@nuvoton.com>
+
+description:
+  The NPCM8xx supports the Intel Enhanced Serial Peripheral Interface (eSPI) Revision 1.0.
+
+properties:
+  compatible:
+    items:
+      - enum:
+          - nuvoton,npcm845-espi
+      - const: simple-mfd
+      - const: syscon
+
+  reg:
+    maxItems: 1
+
+patternProperties:
+  "^vw_gpio@[0-9a-f]+$":
+    type: object
+    additionalProperties: false
+
+    description: |
+      This VWGPIO controller is for NUVOTON NPCM8xx SoC, NPCM8xx has one
+      vwgpio module can support up to 64 output pins (VWGPSM0-15), and
+      up to 64 input pins (VWGPMS0-15), in this order.
+      VWGPIO pins can be programmed to support interrupt option for each
+      input port and various interrupt sensitivity option (level-high,
+      level-low, edge-high, edge-low)
+
+    properties:
+      compatible:
+        items:
+          - enum:
+              - nuvoton,npcm845-espi-vwgpio
+
+      interrupts:
+        maxItems: 1
+
+      gpio-controller: true
+
+      '#gpio-cells':
+        const: 2
+
+      nuvoton,gpio-control-map:
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2, 3]
+        default: 0
+        description: |
+          Controls the mapping of all the GPIO Virtual Wires (VWGPSM0-15,
+          VWGPMS0-15, in this order) to indices as follows
+            0: 80-111 (50h-6Fh) (default)
+            1: 128-159 (80h-9Fh)
+            2: 160-191 (A0h-BFh)
+            3: 192-223 (C0h-DFh)
+
+      nuvoton,control-interrupt-map:
+        $ref: /schemas/types.yaml#/definitions/uint32
+        enum: [0, 1, 2, 3]
+        default: 0
+        description: |
+          Controls the mapping of interrupts 15-0 (in this order) originating
+          from the device modules to the reported IRQ lines of the Host.
+            0: 15-0 (default)
+            1: 31-16
+            2: 47-32
+            3: 63-48
+
+      nuvoton,index-en-map:
+        $ref: /schemas/types.yaml#/definitions/uint32
+        minimum: 0x0
+        maximum: 0xFFFFFFFF
+        default: 0x0
+        description: |
+          Defines the index of the Virtual Wire group (VWGPMS15-0, VWGPSM15-0,
+          in this order)
+
+    required:
+      - compatible
+      - interrupts
+      - gpio-controller
+      - '#gpio-cells'
+      - nuvoton,gpio-control-map
+      - nuvoton,control-interrupt-map
+      - nuvoton,index-en-map
+
+required:
+  - compatible
+  - reg
+
+additionalProperties:
+  type: object
+
+examples:
+  - |
+    #include <dt-bindings/interrupt-controller/arm-gic.h>
+
+    espi: espi@9f000 {
+        compatible = "nuvoton,npcm845-espi", "simple-mfd", "syscon";
+        reg = <0x9F000 0x1000>;
+
+        vw_gpio: vw_gpio {
+            compatible = "nuvoton,npcm845-espi-vwgpio";
+            interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
+            gpio-controller;
+            #gpio-cells = <2>;
+            nuvoton,gpio-control-map = <1>;
+            nuvoton,control-interrupt-map = <0>;
+            nuvoton,index-en-map = <0x80000000>;
+        };
+    };

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -279,15 +279,17 @@
 				};
 			};
 
-			espi_vw: espi_vw@9f000 {
-				compatible = "nuvoton,npcm8xx-espi-vw";
+			espi: espi@9f000 {
+				compatible = "nuvoton,npcm845-espi",
+						"simple-mfd", "syscon";
 				reg = <0x9f000 0x1000>;
-				interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
-				gpio-controller;
-				#gpio-cells = <2>;
-				pinctrl-names = "default";
-				pinctrl-0 = <&espi_pins>;
-				status = "disabled";
+				vw_gpio: vw_gpio {
+					compatible = "nuvoton,npcm845-espi-vwgpio";
+					interrupts = <GIC_SPI 18 IRQ_TYPE_LEVEL_HIGH>;
+					gpio-controller;
+					#gpio-cells = <2>;
+					status = "disabled";
+				};
 			};
 
 			peci: peci-controller@100000 {

--- a/drivers/soc/nuvoton/Kconfig
+++ b/drivers/soc/nuvoton/Kconfig
@@ -14,11 +14,11 @@ config NPCM_MBOX_CERBERUS
 	  processors on the BMC such as TIP and CP. 
 	  Select Y here if you want to use NPCM mailbox controller.
 
-config NPCM_ESPI_VW
-	tristate "NPCM eSPI Virtual Wire"
+config NPCM_ESPI_VWGPIO
+	tristate "NPCM eSPI Virtual Wire GPIO"
 	depends on ARCH_NPCM || COMPILE_TEST
 	help
-	  An implementation of the NPCM eSPI virutal wire driver.
+	  An implementation of the NPCM eSPI virutal wire gpio driver.
 	  It is used to control the virtual wire master-to-slave and
 	  slave-to-master GPIO. It also registers an gpio controller
 	  to handle the master-to-slave gpio event.

--- a/drivers/soc/nuvoton/Makefile
+++ b/drivers/soc/nuvoton/Makefile
@@ -1,4 +1,4 @@
 # SPDX-License-Identifier: GPL-2.0-only
 obj-$(CONFIG_NPCM_MBOX_CERBERUS) += npcm-cerberus.o
-obj-$(CONFIG_NPCM_ESPI_VW) += npcm-espi-vw.o
+obj-$(CONFIG_NPCM_ESPI_VWGPIO) += npcm-espi-vwgpio.o
 


### PR DESCRIPTION
1. Rename compatible string to be specific to vw gpio
2. Create espi dts node for defining the shared reg resource. vw_gpio is a child node that declare the driver specific properties.
3. Add device tree bindings for the vwgpio NPCM.