### PR TITLE
dt-bindings: gpio: add NPCM sgpio driver bindings

### DIFF
--- a/Documentation/devicetree/bindings/gpio/nuvoton,sgpio.yaml
+++ b/Documentation/devicetree/bindings/gpio/nuvoton,sgpio.yaml
@@ -9,16 +9,20 @@ title: Nuvoton SGPIO controller
 maintainers:
   - Jim LIU <JJLIU0@nuvoton.com>
 
-description:
-  This SGPIO controller is for NUVOTON NPCM7xx and NPCM8xx SoC,
+description: |
+  This SGPIO controller is for NUVOTON NPCM7xx and NPCM8xx SoC.
+  Nuvoton NPCM7xx SGPIO module is combine serial to parallel IC (HC595)
+  and parallel to serial IC (HC165), and use APB3 clock to control it.
+  This interface has 4 pins  (D_out , D_in, S_CLK, LDSH).
   NPCM7xx/NPCM8xx have two sgpio module each module can support up
-  to 64 output pins,and up to 64 input pin.
+  to 64 output pins,and up to 64 input pin, the pin is only for gpi or gpo.
+  GPIO pins have sequential, First half is gpo and second half is gpi.
   GPIO pins can be programmed to support the following options
   - Support interrupt option for each input port and various interrupt
     sensitivity option (level-high, level-low, edge-high, edge-low)
-  - Directly connected to APB bus and its shift clock is from APB bus clock
-    divided by a programmable value.
-  - ngpios is number of nin_gpios GPIO lines and nout_gpios GPIO lines.
+  - ngpios is number of nuvoton,input-ngpios GPIO lines and nuvoton,output-ngpios GPIO lines.
+    nuvoton,input-ngpios GPIO lines is only for gpi.
+    nuvoton,output-ngpios GPIO lines is only for gpo.
 
 properties:
   compatible:
@@ -40,11 +44,19 @@ properties:
   clocks:
     maxItems: 1
 
-  nin_gpios: true
+  nuvoton,input-ngpios:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description:
+      The numbers of GPIO's exposed. GPIO lines is only for gpi.
+    minimum: 0
+    maximum: 64
 
-  nout_gpios: true
-
-  bus-frequency: true
+  nuvoton,output-ngpios:
+    $ref: /schemas/types.yaml#/definitions/uint32
+    description:
+      The numbers of GPIO's exposed. GPIO lines is only for gpo.
+    minimum: 0
+    maximum: 64
 
 required:
   - compatible
@@ -52,10 +64,9 @@ required:
   - gpio-controller
   - '#gpio-cells'
   - interrupts
-  - nin_gpios
-  - nout_gpios
+  - nuvoton,input-ngpios
+  - nuvoton,output-ngpios
   - clocks
-  - bus-frequency
 
 additionalProperties: false
 
@@ -63,16 +74,13 @@ examples:
   - |
     #include <dt-bindings/clock/nuvoton,npcm7xx-clock.h>
     #include <dt-bindings/interrupt-controller/arm-gic.h>
-    sgpio1: sgpio@101000 {
+    gpio8: gpio@101000 {
         compatible = "nuvoton,npcm750-sgpio";
-        gpio-controller;
-        #gpio-cells = <2>;
-        interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
         reg = <0x101000 0x200>;
         clocks = <&clk NPCM7XX_CLK_APB3>;
-        pinctrl-names = "default";
-        pinctrl-0 = <&iox1_pins>;
-        nin_gpios = <64>;
-        nout_gpios = <64>;
-        bus-frequency = <16000000>;
+        interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+        gpio-controller;
+        #gpio-cells = <2>;
+        nuvoton,input-ngpios = <64>;
+        nuvoton,output-ngpios = <64>;
     };


### PR DESCRIPTION
Add dt-bindings document for the Nuvoton NPCM sgpio driver