### PR TITLE
update i3c master svc driver

### DIFF
--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -557,6 +557,7 @@ static void svc_i3c_master_ibi_work(struct work_struct *work)
 	if (ret) {
 		dev_err(master->dev, "Timeout when polling for IBIWON\n");
 		svc_i3c_master_clear_merrwarn(master);
+		svc_i3c_master_emit_stop(master);
 		goto reenable_ibis;
 	}
 

--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -258,6 +258,7 @@ struct npcm_dma_xfer_desc {
  * @ibi.slots: Available IBI slots
  * @ibi.tbq_slot: To be queued IBI slot
  * @ibi.lock: IBI lock
+ * @lock: Transfer lock, protect between IBI work thread and callbacks from master
  */
 struct svc_i3c_master {
 	struct i3c_master_controller base;
@@ -282,7 +283,6 @@ struct svc_i3c_master {
 		struct list_head list;
 		struct svc_i3c_xfer *cur;
 		/* Prevent races between transfers */
-		struct mutex lock;
 	} xferqueue;
 	struct {
 		unsigned int num_slots;
@@ -291,6 +291,7 @@ struct svc_i3c_master {
 		/* Prevent races within IBI handlers */
 		spinlock_t lock;
 	} ibi;
+	struct mutex lock;
 	struct dentry *debugfs;
 
 	struct {
@@ -544,6 +545,7 @@ static void svc_i3c_master_ibi_work(struct work_struct *work)
 	u32 status, val;
 	int ret;
 
+	mutex_lock(&master->lock);
 	/* Acknowledge the incoming interrupt with the AUTOIBI mechanism */
 	writel(SVC_I3C_MCTRL_REQUEST_AUTO_IBI |
 	       SVC_I3C_MCTRL_IBIRESP_AUTO,
@@ -629,6 +631,7 @@ reenable_ibis:
 	/* Clear AUTOIBI in case it is not started yet */
 	writel(0, master->regs + SVC_I3C_MCTRL);
 	svc_i3c_master_enable_interrupts(master, SVC_I3C_MINT_SLVSTART);
+	mutex_unlock(&master->lock);
 }
 
 static irqreturn_t svc_i3c_master_irq_handler(int irq, void *dev_id)
@@ -1105,7 +1108,7 @@ static int svc_i3c_master_do_daa(struct i3c_master_controller *m)
 		return ret;
 	}
 
-	mutex_lock(&master->xferqueue.lock);
+	mutex_lock(&master->lock);
 	local_irq_disable();
 	/*
 	 * Fix SCL/SDA timing issue during DAA.
@@ -1116,7 +1119,7 @@ static int svc_i3c_master_do_daa(struct i3c_master_controller *m)
 	ret = svc_i3c_master_do_daa_locked(master, addrs, &dev_nb);
 	svc_i3c_master_set_sda_skew(master, 0);
 	local_irq_enable();
-	mutex_unlock(&master->xferqueue.lock);
+	mutex_unlock(&master->lock);
 	if (ret) {
 		svc_i3c_master_emit_stop(master);
 		svc_i3c_master_clear_merrwarn(master);
@@ -1489,9 +1492,9 @@ static void svc_i3c_master_dequeue_xfer_locked(struct svc_i3c_master *master,
 static void svc_i3c_master_dequeue_xfer(struct svc_i3c_master *master,
 					struct svc_i3c_xfer *xfer)
 {
-	mutex_lock(&master->xferqueue.lock);
+	mutex_lock(&master->lock);
 	svc_i3c_master_dequeue_xfer_locked(master, xfer);
-	mutex_unlock(&master->xferqueue.lock);
+	mutex_unlock(&master->lock);
 }
 
 static void svc_i3c_master_start_xfer_locked(struct svc_i3c_master *master)
@@ -1545,14 +1548,14 @@ static void svc_i3c_master_enqueue_xfer(struct svc_i3c_master *master,
 					struct svc_i3c_xfer *xfer)
 {
 	init_completion(&xfer->comp);
-	mutex_lock(&master->xferqueue.lock);
+	mutex_lock(&master->lock);
 	if (master->xferqueue.cur) {
 		list_add_tail(&xfer->node, &master->xferqueue.list);
 	} else {
 		master->xferqueue.cur = xfer;
 		svc_i3c_master_start_xfer_locked(master);
 	}
-	mutex_unlock(&master->xferqueue.lock);
+	mutex_unlock(&master->lock);
 }
 
 static bool
@@ -2356,7 +2359,7 @@ static int svc_i3c_master_probe(struct platform_device *pdev)
 
 	master->free_slots = GENMASK(SVC_I3C_MAX_DEVS - 1, 0);
 
-	mutex_init(&master->xferqueue.lock);
+	mutex_init(&master->lock);
 	INIT_LIST_HEAD(&master->xferqueue.list);
 
 	spin_lock_init(&master->ibi.lock);

--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -2452,6 +2452,9 @@ static int svc_i3c_master_probe(struct platform_device *pdev)
 	if (!of_property_read_u32(dev->of_node, "i3c-od-scl-lo-period-ns", &val))
 		master->scl_timing.i3c_od_lo = val;
 
+	svc_i3c_master_clear_merrwarn(master);
+	svc_i3c_master_flush_fifo(master);
+
 	svc_i3c_setup_dma(pdev, master);
 	svc_i3c_init_debugfs(pdev, master);
 

--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -330,6 +330,8 @@ struct svc_i3c_i2c_dev_data {
 	struct i3c_generic_ibi_pool *ibi_pool;
 };
 
+static int svc_i3c_master_wait_for_complete(struct svc_i3c_master *master);
+
 static bool svc_i3c_master_error(struct svc_i3c_master *master)
 {
 	u32 mstatus, merrwarn;
@@ -412,19 +414,10 @@ to_svc_i3c_master(struct i3c_master_controller *master)
 static void svc_i3c_master_hj_work(struct work_struct *work)
 {
 	struct svc_i3c_master *master;
-	u32 mint;
 
 	master = container_of(work, struct svc_i3c_master, hj_work);
 
-	/* disable IBI/HJ interrupt during DAA */
-	mint = readl(master->regs + SVC_I3C_MINTSET);
-	if (mint & SVC_I3C_MINT_SLVSTART)
-		writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTCLR);
-
 	i3c_master_do_daa(&master->base);
-
-	if (mint & SVC_I3C_MINT_SLVSTART)
-		writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTSET);
 }
 
 static struct i3c_dev_desc *
@@ -462,14 +455,16 @@ static void svc_i3c_master_emit_stop(struct svc_i3c_master *master)
 }
 
 static int svc_i3c_master_handle_ibi(struct svc_i3c_master *master,
-				     struct i3c_dev_desc *dev)
+				     struct i3c_dev_desc *dev,
+				     int use_dma)
 {
 	struct svc_i3c_i2c_dev_data *data = i3c_dev_get_master_data(dev);
+	struct npcm_dma_xfer_desc *xfer = &master->dma_xfer;
 	struct i3c_ibi_slot *slot;
 	unsigned int count;
 	u32 mdatactrl;
 	u32 val;
-	int ret;
+	int ret, ibi_count;
 	u8 *buf;
 
 	slot = i3c_generic_ibi_get_free_slot(data->ibi_pool);
@@ -484,6 +479,19 @@ static int svc_i3c_master_handle_ibi(struct svc_i3c_master *master,
 	if (ret) {
 		dev_err(master->dev, "Timeout when polling for COMPLETE\n");
 		return ret;
+	}
+
+	if (use_dma) {
+		if (slot->len < SVC_I3C_MAX_IBI_PAYLOAD_SIZE) {
+			ibi_count = svc_i3c_master_wait_for_complete(master);
+			if (ibi_count <= SVC_I3C_MAX_IBI_PAYLOAD_SIZE) {
+				memcpy(buf, xfer->in, ibi_count);
+				slot->len += ibi_count;
+			}
+			else
+				dev_err(master->dev, "DMA read fail to fit slot len = 0x%x\n", ibi_count);
+		}
+		goto handle_done;
 	}
 
 	while (slot->len < SVC_I3C_MAX_IBI_PAYLOAD_SIZE) {
@@ -504,6 +512,7 @@ static int svc_i3c_master_handle_ibi(struct svc_i3c_master *master,
 			break;
 	}
 
+handle_done:
 	master->ibi.tbq_slot = slot;
 
 	return 0;
@@ -577,7 +586,7 @@ static void svc_i3c_master_ibi_work(struct work_struct *work)
 		if (!dev)
 			svc_i3c_master_nack_ibi(master);
 		else
-			svc_i3c_master_handle_ibi(master, dev);
+			svc_i3c_master_handle_ibi(master, dev, false);
 		break;
 	case SVC_I3C_MSTATUS_IBITYPE_HOT_JOIN:
 		svc_i3c_master_ack_ibi(master, false);
@@ -602,6 +611,7 @@ static void svc_i3c_master_ibi_work(struct work_struct *work)
 			master->ibi.tbq_slot = NULL;
 		}
 
+		dev_err(master->dev, "svc_i3c_master_error in ibi work\n");
 		svc_i3c_master_emit_stop(master);
 
 		goto reenable_ibis;
@@ -708,6 +718,80 @@ static irqreturn_t svc_i3c_master_irq_handler(int irq, void *dev_id)
 	}
 
 	return IRQ_HANDLED;
+}
+
+static void svc_i3c_master_handle_ibiwon(struct svc_i3c_master *master, int use_dma)
+{
+	struct svc_i3c_i2c_dev_data *data;
+	unsigned int ibitype, ibiaddr;
+	struct i3c_dev_desc *dev;
+	u32 status, val;
+
+	status = readl(master->regs + SVC_I3C_MSTATUS);
+	ibitype = SVC_I3C_MSTATUS_IBITYPE(status);
+	ibiaddr = SVC_I3C_MSTATUS_IBIADDR(status);
+
+        /* Handle the critical responses to IBI's */
+	switch (ibitype) {
+	case SVC_I3C_MSTATUS_IBITYPE_IBI:
+		dev = svc_i3c_master_dev_from_addr(master, ibiaddr);
+		if (!dev)
+			svc_i3c_master_nack_ibi(master);
+		else
+			svc_i3c_master_handle_ibi(master, dev, use_dma);
+		break;
+	case SVC_I3C_MSTATUS_IBITYPE_HOT_JOIN:
+		svc_i3c_master_ack_ibi(master, false);
+		break;
+	case SVC_I3C_MSTATUS_IBITYPE_MASTER_REQUEST:
+		svc_i3c_master_nack_ibi(master);
+		break;
+	default:
+		break;
+	}
+
+	/*
+	 * If an error happened, we probably got interrupted and the exchange
+	 * timedout. In this case we just drop everything, emit a stop and wait
+	 * for the slave to interrupt again.
+	 */
+	if (svc_i3c_master_error(master)) {
+		if (master->ibi.tbq_slot) {
+			data = i3c_dev_get_master_data(dev);
+			i3c_generic_ibi_recycle_slot(data->ibi_pool,
+						     master->ibi.tbq_slot);
+			master->ibi.tbq_slot = NULL;
+		}
+
+		dev_err(master->dev, "svc_i3c_master_error in ibiwon\n");
+		svc_i3c_master_emit_stop(master);
+		goto clear_ibiwon;
+	}
+
+	/* Handle the non critical tasks */
+	switch (ibitype) {
+	case SVC_I3C_MSTATUS_IBITYPE_IBI:
+		if (dev) {
+			i3c_master_queue_ibi(dev, master->ibi.tbq_slot);
+			master->ibi.tbq_slot = NULL;
+		}
+		svc_i3c_master_emit_stop(master);
+		break;
+	case SVC_I3C_MSTATUS_IBITYPE_HOT_JOIN:
+		readl_relaxed_poll_timeout(master->regs + SVC_I3C_MSTATUS, val,
+					   SVC_I3C_MSTATUS_MCTRLDONE(val), 0, 1000);
+		/* Emit stop to avoid the INVREQ error after DAA process */
+		svc_i3c_master_emit_stop(master);
+		queue_work(master->base.wq, &master->hj_work);
+		break;
+	case SVC_I3C_MSTATUS_IBITYPE_MASTER_REQUEST:
+	default:
+		break;
+	}
+
+clear_ibiwon:
+	/* clear IBIWON status */
+	writel(SVC_I3C_MINT_IBIWON, master->regs + SVC_I3C_MSTATUS);
 }
 
 static int svc_i3c_master_bus_init(struct i3c_master_controller *m)
@@ -993,7 +1077,7 @@ static int svc_i3c_master_do_daa_locked(struct svc_i3c_master *master,
 		/* Enter/proceed with DAA */
 		writel(SVC_I3C_MCTRL_REQUEST_PROC_DAA |
 		       SVC_I3C_MCTRL_TYPE_I3C |
-		       SVC_I3C_MCTRL_IBIRESP_NACK |
+		       SVC_I3C_MCTRL_IBIRESP_AUTO |
 		       SVC_I3C_MCTRL_DIR(SVC_I3C_MCTRL_DIR_WRITE),
 		       master->regs + SVC_I3C_MCTRL);
 
@@ -1008,6 +1092,12 @@ static int svc_i3c_master_do_daa_locked(struct svc_i3c_master *master,
 						1, 1000);
 		if (ret)
 			return ret;
+
+		/* runtime do_daa may ibiwon by others slave devices */
+		if (SVC_I3C_MSTATUS_IBIWON(reg)) {
+			svc_i3c_master_handle_ibiwon(master, false);
+			continue;
+		}
 
 		if (SVC_I3C_MSTATUS_RXPEND(reg)) {
 			u8 data[6];
@@ -1380,8 +1470,9 @@ static int svc_i3c_master_xfer(struct svc_i3c_master *master,
 			       unsigned int *read_len, bool continued,
 			       bool use_dma)
 {
-	u32 reg, rdterm = *read_len;
+	u32 reg, rdterm = *read_len, mstatus, mint;
 	int ret, i, count, space;
+	unsigned long flags;
 
 	if (rdterm > SVC_I3C_MAX_RDTERM)
 		rdterm = SVC_I3C_MAX_RDTERM;
@@ -1442,9 +1533,10 @@ static int svc_i3c_master_xfer(struct svc_i3c_master *master,
 	if (!use_dma)
 		local_irq_disable();
 
+retry_start:
 	writel(SVC_I3C_MCTRL_REQUEST_START_ADDR |
 	       xfer_type |
-	       SVC_I3C_MCTRL_IBIRESP_NACK |
+	       SVC_I3C_MCTRL_IBIRESP_AUTO |
 	       SVC_I3C_MCTRL_DIR(rnw) |
 	       SVC_I3C_MCTRL_ADDR(addr) |
 	       SVC_I3C_MCTRL_RDTERM(rdterm),
@@ -1454,6 +1546,42 @@ static int svc_i3c_master_xfer(struct svc_i3c_master *master,
 				 SVC_I3C_MSTATUS_MCTRLDONE(reg), 0, 1000);
 	if (ret)
 		goto emit_stop;
+
+	mstatus = readl(master->regs + SVC_I3C_MSTATUS);
+	if (SVC_I3C_MSTATUS_IBIWON(mstatus)) {
+		if (rnw) {
+			/* handle ibi event */
+			svc_i3c_master_handle_ibiwon(master, use_dma);
+
+			/* enable read dma again */
+			if (use_dma) {
+				master->dma_xfer.out = out;
+				master->dma_xfer.in = in;
+				master->dma_xfer.len = xfer_len;
+				master->dma_xfer.rnw = rnw;
+				init_completion(&master->xfer_comp);
+				svc_i3c_master_start_dma(master);
+			}
+		} else {
+			/* handle ibi event */
+			svc_i3c_master_handle_ibiwon(master, false);
+
+			/* for write, re-init xfer_comp and enable complete interrupt */
+			if (use_dma) {
+				/* re-init complete */
+				init_completion(&master->xfer_comp);
+
+				/* Use I3C Complete interrupt to notify the transaction compeltion */
+				spin_lock_irqsave(&master->lock_irq, flags);
+				mint = readl(master->regs + SVC_I3C_MINTSET) | SVC_I3C_MINT_COMPLETE;
+				svc_i3c_master_enable_interrupts(master, mint);
+				spin_unlock_irqrestore(&master->lock_irq, flags);
+			}
+		}
+
+		svc_i3c_master_clear_merrwarn(master);
+		goto retry_start;
+	}
 
 	reg = readl(master->regs + SVC_I3C_MSTATUS);
 	if (SVC_I3C_MSTATUS_NACKED(reg)) {
@@ -1505,6 +1633,7 @@ emit_stop:
 		local_irq_enable();
 	svc_i3c_master_emit_stop(master);
 	svc_i3c_master_clear_merrwarn(master);
+	svc_i3c_master_flush_fifo(master);
 
 	return ret;
 }

--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -1060,8 +1060,10 @@ static int svc_i3c_update_ibirules(struct svc_i3c_master *master)
 
 	/* Create the IBIRULES register for both cases */
 	i3c_bus_for_each_i3cdev(&master->base.bus, dev) {
-		if (I3C_BCR_DEVICE_ROLE(dev->info.bcr) == I3C_BCR_I3C_MASTER)
-			continue;
+		if (I3C_BCR_DEVICE_ROLE(dev->info.bcr) == I3C_BCR_I3C_MASTER) {
+			if (!(dev->info.bcr & I3C_BCR_IBI_REQ_CAP))
+				continue;
+		}
 
 		if (dev->info.bcr & I3C_BCR_IBI_PAYLOAD) {
 			reg_mbyte |= SVC_I3C_IBIRULES_ADDR(mbyte_addr_ok,

--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -1447,13 +1447,9 @@ static int svc_i3c_master_xfer(struct svc_i3c_master *master,
 		}
 	}
 
-	if (!continued) {
+	if (!continued)
 		svc_i3c_master_emit_stop(master);
 
-		/* Wait idle if stop is sent. */
-		readl_poll_timeout(master->regs + SVC_I3C_MSTATUS, reg,
-				   SVC_I3C_MSTATUS_STATE_IDLE(reg), 0, 1000);
-	}
 	if (!use_dma)
 		local_irq_enable();
 

--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -107,6 +107,7 @@
 #define   SVC_I3C_MSTATUS_STATE(x) FIELD_GET(GENMASK(2, 0), (x))
 #define   SVC_I3C_MSTATUS_STATE_DAA(x) (SVC_I3C_MSTATUS_STATE(x) == 5)
 #define   SVC_I3C_MSTATUS_STATE_IDLE(x) (SVC_I3C_MSTATUS_STATE(x) == 0)
+#define   SVC_I3C_MSTATUS_STATE_SLVREQ(x) (SVC_I3C_MSTATUS_STATE(x) == 1)
 #define   SVC_I3C_MSTATUS_BETWEEN(x) FIELD_GET(BIT(4), (x))
 #define   SVC_I3C_MSTATUS_NACKED(x) FIELD_GET(BIT(5), (x))
 #define   SVC_I3C_MSTATUS_IBITYPE(x) FIELD_GET(GENMASK(7, 6), (x))
@@ -444,13 +445,6 @@ svc_i3c_master_dev_from_addr(struct svc_i3c_master *master,
 
 static void svc_i3c_master_emit_stop(struct svc_i3c_master *master)
 {
-	u32 mint;
-
-	/* Temporarily disable slvstart interrupt to prevent spurious event */
-	mint = readl(master->regs + SVC_I3C_MINTSET);
-	if (mint & SVC_I3C_MINT_SLVSTART)
-		writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTCLR);
-
 	if (master->hdr_mode) {
 		writel(SVC_I3C_MCTRL_REQUEST_FORCE_EXIT, master->regs + SVC_I3C_MCTRL);
 		master->hdr_mode = false;
@@ -465,14 +459,6 @@ static void svc_i3c_master_emit_stop(struct svc_i3c_master *master)
 	 * correctly if a start condition follows too rapidly.
 	 */
 	udelay(1);
-
-	/*
-	 * Workaround: clear the spurious SlaveStart event under
-	 * bad signals condition.
-	 */
-	writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MSTATUS);
-	if (mint & SVC_I3C_MINT_SLVSTART)
-		writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTSET);
 }
 
 static int svc_i3c_master_handle_ibi(struct svc_i3c_master *master,
@@ -550,10 +536,17 @@ static void svc_i3c_master_ibi_work(struct work_struct *work)
 	struct svc_i3c_i2c_dev_data *data;
 	unsigned int ibitype, ibiaddr;
 	struct i3c_dev_desc *dev;
-	u32 status, val;
+	u32 status, val, mstatus;
 	int ret;
 
 	mutex_lock(&master->lock);
+
+	/* Check slave ibi handled not yet */
+	mstatus = readl(master->regs + SVC_I3C_MSTATUS);
+	if (!SVC_I3C_MSTATUS_STATE_SLVREQ(mstatus)) {
+		goto handle_done;
+	}
+
 	/* Acknowledge the incoming interrupt with the AUTOIBI mechanism */
 	writel(SVC_I3C_MCTRL_REQUEST_AUTO_IBI |
 	       SVC_I3C_MCTRL_IBIRESP_AUTO,
@@ -639,6 +632,8 @@ reenable_ibis:
 	writel(SVC_I3C_MINT_IBIWON, master->regs + SVC_I3C_MSTATUS);
 	/* Clear AUTOIBI in case it is not started yet */
 	writel(0, master->regs + SVC_I3C_MCTRL);
+
+handle_done:
 	svc_i3c_master_enable_interrupts(master, SVC_I3C_MINT_SLVSTART);
 	mutex_unlock(&master->lock);
 }
@@ -646,24 +641,58 @@ reenable_ibis:
 static irqreturn_t svc_i3c_master_irq_handler(int irq, void *dev_id)
 {
 	struct svc_i3c_master *master = (struct svc_i3c_master *)dev_id;
-	u32 active = readl(master->regs + SVC_I3C_MINTMASKED);
+	u32 active = readl(master->regs + SVC_I3C_MINTMASKED), mstatus;
 
 	if (SVC_I3C_MSTATUS_COMPLETE(active)) {
 		/* Disable COMPLETE interrupt */
 		writel(SVC_I3C_MINT_COMPLETE, master->regs + SVC_I3C_MINTCLR);
 
 		complete(&master->xfer_comp);
+
+		return IRQ_HANDLED;
 	}
 
 	if (SVC_I3C_MSTATUS_SLVSTART(active)) {
 		/* Clear the interrupt status */
 		writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MSTATUS);
 
-		/* Disable SLVSTART interrupt */
-		writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTCLR);
+		/* Read I3C state */
+		mstatus = readl(master->regs + SVC_I3C_MSTATUS);
 
-		/* Handle the interrupt in a non atomic context */
-		queue_work(master->base.wq, &master->ibi_work);
+		if (SVC_I3C_MSTATUS_STATE_SLVREQ(mstatus)) {
+			/* Disable SLVSTART interrupt */
+			writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTCLR);
+
+			/* Handle the interrupt in a non atomic context */
+			queue_work(master->base.wq, &master->ibi_work);
+		}
+		else {
+			/*
+			 * Workaround:
+			 * SlaveStart event under bad signals condition. SLVSTART bit in
+			 * MSTATUS may set even slave device doesn't holding I3C_SDA low,
+			 * but actual SlaveStart event may happened concurently in this
+			 * bad signals condition handler. Give a chance to check current
+			 * work state and intmask to avoid actual SlaveStart cannot be
+			 * trigger after we clear SlaveStart interrupt status.
+			 */
+
+			/* Check if state change after we clear interrupt status */
+			active = readl(master->regs + SVC_I3C_MINTMASKED);
+			mstatus = readl(master->regs + SVC_I3C_MSTATUS);
+
+			if (SVC_I3C_MSTATUS_STATE_SLVREQ(mstatus)) {
+				if (!SVC_I3C_MSTATUS_SLVSTART(active)) {
+					/* Disable SLVSTART interrupt */
+					writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTCLR);
+					/* Handle the interrupt in a non atomic context */
+					queue_work(master->base.wq, &master->ibi_work);
+				}
+				else {
+					/* handle interrupt in next time */
+				}
+			}
+		}
 	}
 
 	return IRQ_HANDLED;

--- a/drivers/i3c/master/svc-i3c-master.c
+++ b/drivers/i3c/master/svc-i3c-master.c
@@ -293,6 +293,7 @@ struct svc_i3c_master {
 		spinlock_t lock;
 	} ibi;
 	struct mutex lock;
+	spinlock_t lock_irq;
 	struct dentry *debugfs;
 
 	struct {
@@ -311,7 +312,6 @@ struct svc_i3c_master {
 	dma_addr_t dma_tx_addr;
 	dma_addr_t dma_rx_addr;
 	struct npcm_dma_xfer_desc dma_xfer;
-	u32 mint_save;
 
 	bool en_hj;
 	bool hdr_ddr;
@@ -535,8 +535,9 @@ static void svc_i3c_master_ibi_work(struct work_struct *work)
 	struct svc_i3c_master *master = container_of(work, struct svc_i3c_master, ibi_work);
 	struct svc_i3c_i2c_dev_data *data;
 	unsigned int ibitype, ibiaddr;
+	unsigned long flags;
 	struct i3c_dev_desc *dev;
-	u32 status, val, mstatus;
+	u32 status, val, mstatus, mint;
 	int ret;
 
 	mutex_lock(&master->lock);
@@ -634,7 +635,10 @@ reenable_ibis:
 	writel(0, master->regs + SVC_I3C_MCTRL);
 
 handle_done:
-	svc_i3c_master_enable_interrupts(master, SVC_I3C_MINT_SLVSTART);
+	spin_lock_irqsave(&master->lock_irq, flags);
+	mint = readl(master->regs + SVC_I3C_MINTSET) | SVC_I3C_MINT_SLVSTART;
+	svc_i3c_master_enable_interrupts(master, mint);
+	spin_unlock_irqrestore(&master->lock_irq, flags);
 	mutex_unlock(&master->lock);
 }
 
@@ -642,10 +646,13 @@ static irqreturn_t svc_i3c_master_irq_handler(int irq, void *dev_id)
 {
 	struct svc_i3c_master *master = (struct svc_i3c_master *)dev_id;
 	u32 active = readl(master->regs + SVC_I3C_MINTMASKED), mstatus;
+	unsigned long flags;
 
 	if (SVC_I3C_MSTATUS_COMPLETE(active)) {
 		/* Disable COMPLETE interrupt */
+		spin_lock_irqsave(&master->lock_irq, flags);
 		writel(SVC_I3C_MINT_COMPLETE, master->regs + SVC_I3C_MINTCLR);
+		spin_unlock_irqrestore(&master->lock_irq, flags);
 
 		complete(&master->xfer_comp);
 
@@ -661,7 +668,9 @@ static irqreturn_t svc_i3c_master_irq_handler(int irq, void *dev_id)
 
 		if (SVC_I3C_MSTATUS_STATE_SLVREQ(mstatus)) {
 			/* Disable SLVSTART interrupt */
+			spin_lock_irqsave(&master->lock_irq, flags);
 			writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTCLR);
+			spin_unlock_irqrestore(&master->lock_irq, flags);
 
 			/* Handle the interrupt in a non atomic context */
 			queue_work(master->base.wq, &master->ibi_work);
@@ -684,7 +693,10 @@ static irqreturn_t svc_i3c_master_irq_handler(int irq, void *dev_id)
 			if (SVC_I3C_MSTATUS_STATE_SLVREQ(mstatus)) {
 				if (!SVC_I3C_MSTATUS_SLVSTART(active)) {
 					/* Disable SLVSTART interrupt */
+					spin_lock_irqsave(&master->lock_irq, flags);
 					writel(SVC_I3C_MINT_SLVSTART, master->regs + SVC_I3C_MINTCLR);
+					spin_unlock_irqrestore(&master->lock_irq, flags);
+
 					/* Handle the interrupt in a non atomic context */
 					queue_work(master->base.wq, &master->ibi_work);
 				}
@@ -1253,15 +1265,16 @@ static int svc_i3c_master_write(struct svc_i3c_master *master,
 
 static void svc_i3c_master_stop_dma(struct svc_i3c_master *master)
 {
+	unsigned long flags;
+
 	writel(0, master->dma_regs + NPCM_GDMA_CTL(DMA_CH_TX));
 	writel(0, master->dma_regs + NPCM_GDMA_CTL(DMA_CH_RX));
 	writel(0, master->regs + SVC_I3C_MDMACTRL);
 
 	/* Disable COMPLETE interrupt */
+	spin_lock_irqsave(&master->lock_irq, flags);
 	writel(SVC_I3C_MINT_COMPLETE, master->regs + SVC_I3C_MINTCLR);
-
-	/* Restore the interrupt mask */
-	svc_i3c_master_enable_interrupts(master, master->mint_save);
+	spin_unlock_irqrestore(&master->lock_irq, flags);
 }
 
 static void svc_i3c_master_write_dma_table(const u8 *src, u32 *dst, int len)
@@ -1282,7 +1295,8 @@ static int svc_i3c_master_start_dma(struct svc_i3c_master *master)
 {
 	struct npcm_dma_xfer_desc *xfer = &master->dma_xfer;
 	int ch = xfer->rnw ? DMA_CH_RX : DMA_CH_TX;
-	u32 val;
+	u32 val, mint;
+	unsigned long flags;
 
 	if (!xfer->len)
 		return 0;
@@ -1299,11 +1313,11 @@ static int svc_i3c_master_start_dma(struct svc_i3c_master *master)
 					       (u32 *)master->dma_tx_buf,
 					       xfer->len);
 
-	/* Disable all other i3c interrupts */
-	master->mint_save = readl(master->regs + SVC_I3C_MINTSET);
-	svc_i3c_master_disable_interrupts(master);
 	/* Use I3C Complete interrupt to notify the transaction compeltion */
-	svc_i3c_master_enable_interrupts(master, SVC_I3C_MINT_COMPLETE);
+	spin_lock_irqsave(&master->lock_irq, flags);
+	mint = readl(master->regs + SVC_I3C_MINTSET) | SVC_I3C_MINT_COMPLETE;
+	svc_i3c_master_enable_interrupts(master, mint);
+	spin_unlock_irqrestore(&master->lock_irq, flags);
 
 	/*
 	 * Setup I3C DMA control
@@ -2396,6 +2410,7 @@ static int svc_i3c_master_probe(struct platform_device *pdev)
 	master->free_slots = GENMASK(SVC_I3C_MAX_DEVS - 1, 0);
 
 	mutex_init(&master->lock);
+	spin_lock_init(&master->lock_irq);
 	INIT_LIST_HEAD(&master->xferqueue.list);
 
 	spin_lock_init(&master->ibi.lock);


### PR DESCRIPTION
update i3c master svc driver

Doesn't merge commits below:
i3c: master: svc: fix check wrong status register in irq handler 
-> We use MINTMASKED flag to check which interrupt actived by I3C hw, so
     don't need the patch currently.

i3c: master: svc: fix random hot join failure since timeout error
-> Use for Hot-join case, don't need the patch currently.

i3c: master: svc: fix compatibility string mismatch with binding doc
-> driver compatible name,  don't need the patch currently.