### PR TITLE
rtc: nuvoton: Update compatiblity between NCT3015Y-R and NCT3018Y-R

### DIFF
--- a/Documentation/devicetree/bindings/rtc/nuvoton,nct3018y.yaml
+++ b/Documentation/devicetree/bindings/rtc/nuvoton,nct3018y.yaml
@@ -15,9 +15,7 @@ maintainers:
 
 properties:
   compatible:
-    enum:
-      - nuvoton,nct3018y
-      - nuvoton,nct3015y
+    const: nuvoton,nct3018y
 
   reg:
     maxItems: 1


### PR DESCRIPTION
The NCT3015Y-R and NCT3018Y-R use the same datasheet
    but have different topologies as follows.
- Topology (Only 1st i2c can set TWO bit and HF bit) In NCT3015Y-R, rtc 1st i2c is connected to a host CPU rtc 2nd i2c is connected to a BMC In NCT3018Y-R, rtc 1st i2c is connected to a BMC rtc 2nd i2c is connected to a host CPU In order to be compatible with NCT3015Y-R and NCT3018Y-R,
- In probe, If part number is NCT3018Y-R, only set HF bit to 24-Hour format. Else, do nothing
- In set_time, If part number is NCT3018Y-R && TWO bit is 0, change TWO bit to 1, and restore TWO bit after updating time.