### PR TITLE
pinctrl: npcm8xx: Correct sg1mdio/smi/pspi and remove unused pins

### DIFF
--- a/drivers/pinctrl/nuvoton/pinctrl-npcm8xx.c
+++ b/drivers/pinctrl/nuvoton/pinctrl-npcm8xx.c
@@ -432,7 +432,6 @@ static const int smb4_pins[]  = { 28, 29 };
 static const int smb4b_pins[] = { 18, 19 };
 static const int smb4c_pins[] = { 20, 21 };
 static const int smb4d_pins[] = { 22, 23 };
-static const int smb4den_pins[] = { 17 };
 static const int smb5_pins[]  = { 26, 27 };
 static const int smb5b_pins[] = { 13, 12 };
 static const int smb5c_pins[] = { 15, 14 };
@@ -500,9 +499,8 @@ static const int pwm11_pins[] = { 235 };
 static const int uart1_pins[] = { 43, 45, 46, 47, 61, 62, 63 };
 static const int uart2_pins[] = { 48, 49, 50, 51, 52, 53, 54, 55 };
 
-static const int rg1_pins[] = { 96, 97, 98, 99, 100, 101, 102, 103, 104, 105,
-	106, 107 };
-static const int rg1mdio_pins[] = { 108, 109 };
+/* SGMII 1 MD interface pin group */
+static const int sg1mdio_pins[] = { 108, 109 };
 static const int rg2_pins[] = { 110, 111, 112, 113, 208, 209, 210, 211, 212,
 	213, 214, 215 };
 static const int rg2mdio_pins[] = { 216, 217 };
@@ -539,7 +537,7 @@ static const int bmcuart0b_pins[] = { 48, 49 };
 static const int bmcuart1_pins[] = { 43, 44, 62, 63 };
 
 static const int scipme_pins[] = { 169 };
-static const int sci_pins[] = { 170 };
+static const int smi_pins[] = { 170 };
 static const int serirq_pins[] = { 168 };
 
 static const int clkout_pins[] = { 160 };
@@ -562,7 +560,7 @@ static const int spi3cs3_pins[] = { 189 };
 static const int spix_pins[] = { 224, 225, 226, 227, 229, 230 };
 static const int spixcs1_pins[] = { 228 };
 
-static const int pspi2_pins[] = { 17, 18, 19 };
+static const int pspi_pins[] = { 17, 18, 19 };
 
 static const int gspi_pins[] = { 12, 13, 14, 15 };
 
@@ -699,7 +697,6 @@ struct npcm8xx_pingroup {
 	NPCM8XX_GRP(smb4b), \
 	NPCM8XX_GRP(smb4c), \
 	NPCM8XX_GRP(smb4d), \
-	NPCM8XX_GRP(smb4den), \
 	NPCM8XX_GRP(smb5), \
 	NPCM8XX_GRP(smb5b), \
 	NPCM8XX_GRP(smb5c), \
@@ -762,8 +759,7 @@ struct npcm8xx_pingroup {
 	NPCM8XX_GRP(pwm9), \
 	NPCM8XX_GRP(pwm10), \
 	NPCM8XX_GRP(pwm11), \
-	NPCM8XX_GRP(rg1), \
-	NPCM8XX_GRP(rg1mdio), \
+	NPCM8XX_GRP(sg1mdio), \
 	NPCM8XX_GRP(rg2), \
 	NPCM8XX_GRP(rg2mdio), \
 	NPCM8XX_GRP(ddr), \
@@ -792,13 +788,13 @@ struct npcm8xx_pingroup {
 	NPCM8XX_GRP(wdog1), \
 	NPCM8XX_GRP(wdog2), \
 	NPCM8XX_GRP(scipme), \
-	NPCM8XX_GRP(sci), \
+	NPCM8XX_GRP(smi), \
 	NPCM8XX_GRP(serirq), \
 	NPCM8XX_GRP(jtag2), \
 	NPCM8XX_GRP(spix), \
 	NPCM8XX_GRP(spixcs1), \
 	NPCM8XX_GRP(spi1), \
-	NPCM8XX_GRP(pspi2), \
+	NPCM8XX_GRP(pspi), \
 	NPCM8XX_GRP(ddc), \
 	NPCM8XX_GRP(clkreq), \
 	NPCM8XX_GRP(clkout), \
@@ -948,7 +944,6 @@ NPCM8XX_SFUNC(smb4);
 NPCM8XX_SFUNC(smb4b);
 NPCM8XX_SFUNC(smb4c);
 NPCM8XX_SFUNC(smb4d);
-NPCM8XX_SFUNC(smb4den);
 NPCM8XX_SFUNC(smb5);
 NPCM8XX_SFUNC(smb5b);
 NPCM8XX_SFUNC(smb5c);
@@ -1011,8 +1006,7 @@ NPCM8XX_SFUNC(pwm8);
 NPCM8XX_SFUNC(pwm9);
 NPCM8XX_SFUNC(pwm10);
 NPCM8XX_SFUNC(pwm11);
-NPCM8XX_SFUNC(rg1);
-NPCM8XX_SFUNC(rg1mdio);
+NPCM8XX_SFUNC(sg1mdio);
 NPCM8XX_SFUNC(rg2);
 NPCM8XX_SFUNC(rg2mdio);
 NPCM8XX_SFUNC(ddr);
@@ -1041,13 +1035,13 @@ NPCM8XX_SFUNC(sd1pwr);
 NPCM8XX_SFUNC(wdog1);
 NPCM8XX_SFUNC(wdog2);
 NPCM8XX_SFUNC(scipme);
-NPCM8XX_SFUNC(sci);
+NPCM8XX_SFUNC(smi);
 NPCM8XX_SFUNC(serirq);
 NPCM8XX_SFUNC(jtag2);
 NPCM8XX_SFUNC(spix);
 NPCM8XX_SFUNC(spixcs1);
 NPCM8XX_SFUNC(spi1);
-NPCM8XX_SFUNC(pspi2);
+NPCM8XX_SFUNC(pspi);
 NPCM8XX_SFUNC(ddc);
 NPCM8XX_SFUNC(clkreq);
 NPCM8XX_SFUNC(clkout);
@@ -1173,7 +1167,6 @@ static struct npcm8xx_func npcm8xx_funcs[] = {
 	NPCM8XX_MKFUNC(smb4b),
 	NPCM8XX_MKFUNC(smb4c),
 	NPCM8XX_MKFUNC(smb4d),
-	NPCM8XX_MKFUNC(smb4den),
 	NPCM8XX_MKFUNC(smb5),
 	NPCM8XX_MKFUNC(smb5b),
 	NPCM8XX_MKFUNC(smb5c),
@@ -1236,8 +1229,7 @@ static struct npcm8xx_func npcm8xx_funcs[] = {
 	NPCM8XX_MKFUNC(pwm9),
 	NPCM8XX_MKFUNC(pwm10),
 	NPCM8XX_MKFUNC(pwm11),
-	NPCM8XX_MKFUNC(rg1),
-	NPCM8XX_MKFUNC(rg1mdio),
+	NPCM8XX_MKFUNC(sg1mdio),
 	NPCM8XX_MKFUNC(rg2),
 	NPCM8XX_MKFUNC(rg2mdio),
 	NPCM8XX_MKFUNC(ddr),
@@ -1266,13 +1258,13 @@ static struct npcm8xx_func npcm8xx_funcs[] = {
 	NPCM8XX_MKFUNC(wdog1),
 	NPCM8XX_MKFUNC(wdog2),
 	NPCM8XX_MKFUNC(scipme),
-	NPCM8XX_MKFUNC(sci),
+	NPCM8XX_MKFUNC(smi),
 	NPCM8XX_MKFUNC(serirq),
 	NPCM8XX_MKFUNC(jtag2),
 	NPCM8XX_MKFUNC(spix),
 	NPCM8XX_MKFUNC(spixcs1),
 	NPCM8XX_MKFUNC(spi1),
-	NPCM8XX_MKFUNC(pspi2),
+	NPCM8XX_MKFUNC(pspi),
 	NPCM8XX_MKFUNC(ddc),
 	NPCM8XX_MKFUNC(clkreq),
 	NPCM8XX_MKFUNC(clkout),
@@ -1349,9 +1341,9 @@ static const struct npcm8xx_pincfg pincfg[] = {
 	NPCM8XX_PINCFG(14,	gspi, MFSEL1, 24,	smb5c, I2CSEGSEL, 20,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(15,	gspi, MFSEL1, 24,	smb5c, I2CSEGSEL, 20,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(16,	lkgpo0, FLOCKR1, 0,	smb7b, I2CSEGSEL, 27,	tp_gpio2b, MFSEL7, 10,	none, NONE, 0,		none, NONE, 0,		SLEW),
-	NPCM8XX_PINCFG(17,	pspi2, MFSEL3, 13,	cp1gpio5, MFSEL6, 7,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
-	NPCM8XX_PINCFG(18,	pspi2, MFSEL3, 13,	smb4b, I2CSEGSEL, 14,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
-	NPCM8XX_PINCFG(19,	pspi2, MFSEL3, 13,	smb4b, I2CSEGSEL, 14,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
+	NPCM8XX_PINCFG(17,	pspi, MFSEL3, 13,	cp1gpio5, MFSEL6, 7,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
+	NPCM8XX_PINCFG(18,	pspi, MFSEL3, 13,	smb4b, I2CSEGSEL, 14,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
+	NPCM8XX_PINCFG(19,	pspi, MFSEL3, 13,	smb4b, I2CSEGSEL, 14,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(20,	hgpio0,	MFSEL2, 24,	smb15, MFSEL3, 8,	smb4c, I2CSEGSEL, 15,	none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(21,	hgpio1,	MFSEL2, 25,	smb15, MFSEL3, 8,	smb4c, I2CSEGSEL, 15,	none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(22,	hgpio2,	MFSEL2, 26,	smb14, MFSEL3, 7,	smb4d, I2CSEGSEL, 16,	none, NONE, 0,		none, NONE, 0,		SLEW),
@@ -1428,8 +1420,8 @@ static const struct npcm8xx_pincfg pincfg[] = {
 	NPCM8XX_PINCFG(93,	ga20kbc, MFSEL1, 17,	smb5d, I2CSEGSEL, 21,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(94,	ga20kbc, MFSEL1, 17,	smb5d, I2CSEGSEL, 21,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(95,	lpc, MFSEL1, 26,	espi, MFSEL4, 8,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
-	NPCM8XX_PINCFG(96,	rg1, MFSEL4, 22,	cp1gpio7b, MFSEL6, 24,	tp_gpio7, MFSEL7, 7,	none, NONE, 0,		none, NONE, 0,		SLEW),
-	NPCM8XX_PINCFG(97,	rg1, MFSEL4, 22,	cp1gpio6b, MFSEL6, 25,	tp_gpio6, MFSEL7, 6,	none, NONE, 0,		none, NONE, 0,		SLEW),
+	NPCM8XX_PINCFG(96,	cp1gpio7b, MFSEL6, 24,	tp_gpio7, MFSEL7, 7,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
+	NPCM8XX_PINCFG(97,	cp1gpio6b, MFSEL6, 25,	tp_gpio6, MFSEL7, 6,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(98,	bu4b, MFSEL5, 13,	cp1gpio5b, MFSEL6, 26,	tp_gpio5, MFSEL7, 5,	none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(99,	bu4b, MFSEL5, 13,	cp1gpio4b, MFSEL6, 27,	tp_gpio4, MFSEL7, 4,	none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(100,	bu5b, MFSEL5, 12,	cp1gpio3c, MFSEL6, 28,	tp_gpio3, MFSEL7, 3,	none, NONE, 0,		none, NONE, 0,		SLEW),
@@ -1440,8 +1432,8 @@ static const struct npcm8xx_pincfg pincfg[] = {
 	NPCM8XX_PINCFG(105,	vgadig, MFSEL7, 29,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(106,	i3c5, MFSEL3, 22,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(107,	i3c5, MFSEL3, 22,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
-	NPCM8XX_PINCFG(108,	rg1mdio, MFSEL4, 21,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
-	NPCM8XX_PINCFG(109,	rg1mdio, MFSEL4, 21,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
+	NPCM8XX_PINCFG(108,	sg1mdio, MFSEL4, 21,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
+	NPCM8XX_PINCFG(109,	sg1mdio, MFSEL4, 21,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW),
 	NPCM8XX_PINCFG(110,	rg2, MFSEL4, 24,	ddr, MFSEL3, 26,	rmii3, MFSEL5, 11,	none, NONE, 0,		none, NONE, 0,		SLEW), /* DSCNT */
 	NPCM8XX_PINCFG(111,	rg2, MFSEL4, 24,	ddr, MFSEL3, 26,	rmii3, MFSEL5, 11,	none, NONE, 0,		none, NONE, 0,		SLEW), /* DSCNT */
 	NPCM8XX_PINCFG(112,	rg2, MFSEL4, 24,	ddr, MFSEL3, 26,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		SLEW), /* DSCNT */
@@ -1502,7 +1494,7 @@ static const struct npcm8xx_pincfg pincfg[] = {
 	NPCM8XX_PINCFG(167,	lpc, MFSEL1, 26,	espi, MFSEL4, 8,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(168,	serirq, MFSEL1, 31,	espi, MFSEL4, 8,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(169,	scipme, MFSEL3, 0,	smb21, MFSEL5, 29,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
-	NPCM8XX_PINCFG(170,	sci, MFSEL1, 22,	smb21, MFSEL5, 29,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
+	NPCM8XX_PINCFG(170,	smi, MFSEL1, 22,	smb21, MFSEL5, 29,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(171,	smb6, MFSEL3, 1,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(172,	smb6, MFSEL3, 1,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),
 	NPCM8XX_PINCFG(173,	smb7, MFSEL3, 2,	none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		none, NONE, 0,		0),


### PR DESCRIPTION
Correct sg1mdio/smi/pspi and remove unused pins.