### PR TITLE
ssif_bmc_npcm7xx: remove ARCH_NPCM7xx dependency

### DIFF
--- a/drivers/char/ipmi/Kconfig
+++ b/drivers/char/ipmi/Kconfig
@@ -197,7 +197,7 @@ config SSIF_IPMI_BMC
 	  interface (SSIF).
 
 config NPCM7XX_SSIF_IPMI_BMC
-        depends on ARCH_NPCM7XX || COMPILE_TEST
+        depends on ARCH_NPCM || COMPILE_TEST
         select SSIF_IPMI_BMC
         select I2C_SLAVE
         tristate "Nuvonton SSIF IPMI BMC driver"


### PR DESCRIPTION
Due to ssif_bmc_npcm7xx is common driver for npcm7xx and npcm8xx, remove ARCH_NPCM7xx dependency.