### PR TITLE
spi: npcm-pspi: Handle the rx data when spi transfer set rx_buf

### DIFF
--- a/drivers/spi/spi-npcm-pspi.c
+++ b/drivers/spi/spi-npcm-pspi.c
@@ -160,6 +160,7 @@ static void npcm_pspi_setup_transfer(struct spi_device *spi,
 				     struct spi_transfer *t)
 {
 	struct npcm_pspi *priv = spi_master_get_devdata(spi->master);
+	u8 bits_per_word = 8;
 
 	priv->tx_buf = t->tx_buf;
 	priv->rx_buf = t->rx_buf;
@@ -172,15 +173,14 @@ static void npcm_pspi_setup_transfer(struct spi_device *spi,
 	}
 
 	/*
-	 * If transfer is even length, and 8 bits per word transfer,
-	 * then implement 16 bits-per-word transfer.
+	 * If transfer is even length, change to use 16 bits-per-word transfer.
 	 */
-	if (priv->bits_per_word == 8 && !(t->len & 0x1))
-		t->bits_per_word = 16;
+	if (!(t->len & 0x1))
+		bits_per_word = 16;
 
-	if (!priv->is_save_param || priv->bits_per_word != t->bits_per_word) {
-		npcm_pspi_set_transfer_size(priv, t->bits_per_word);
-		priv->bits_per_word = t->bits_per_word;
+	if (!priv->is_save_param || priv->bits_per_word != bits_per_word) {
+		npcm_pspi_set_transfer_size(priv, bits_per_word);
+		priv->bits_per_word = bits_per_word;
 	}
 
 	if (!priv->is_save_param || priv->speed_hz != t->speed_hz) {
@@ -361,6 +361,7 @@ static int npcm_pspi_probe(struct platform_device *pdev)
 	priv = spi_master_get_devdata(master);
 	priv->master = master;
 	priv->is_save_param = false;
+	priv->bits_per_word = 8;
 
 	priv->base = devm_platform_ioremap_resource(pdev, 0);
 	if (IS_ERR(priv->base)) {
@@ -420,6 +421,9 @@ static int npcm_pspi_probe(struct platform_device *pdev)
 
 	/* set to default clock rate */
 	npcm_pspi_set_baudrate(priv, NPCM_PSPI_DEFAULT_CLK);
+
+	/* set to default data interface mode */
+	npcm_pspi_set_transfer_size(priv, priv->bits_per_word);
 
 	ret = devm_spi_register_master(&pdev->dev, master);
 	if (ret)


### PR DESCRIPTION
The patch fix two problems:

(1) TPM SPI command read data failed.

In TPM spi driver, it will fill tx and rx buffer pointer and check the response data:
https://elixir.bootlin.com/linux/latest/source/drivers/char/tpm/tpm_tis_spi_main.c#L161  => fill tx/rx data pointer.
https://elixir.bootlin.com/linux/latest/source/drivers/char/tpm/tpm_tis_spi_main.c#L54   => depend on the response data to make some action.

Solution:
Handle the rx data when spi transfer set rx_buf.

(2) TPM SPI command failed in the spi framework since pspi driver modify the xfer bits_per_word to 16.

In spi-mem driver, use four spi transfer data structure to pack spi flash command.
https://elixir.bootlin.com/linux/latest/source/drivers/spi/spi-mem.c#L316

Compare with tpm spi driver, only use one spi transfer data structure for write/read transaction.
https://elixir.bootlin.com/linux/latest/source/drivers/char/tpm/tpm_tis_spi_main.c#L146

Since TPM spi driver use the same spi transfer data, suppose tpm spi command transaction only access 1 byte, it will failed.
Please reference below code flow in the spi framework:
https://elixir.bootlin.com/linux/latest/source/drivers/char/tpm/tpm_tis_spi_main.c#L162  => 4 bytes.
https://elixir.bootlin.com/linux/latest/source/drivers/char/tpm/tpm_tis_spi_main.c#L178  => may 1 byte.
https://elixir.bootlin.com/linux/latest/source/drivers/spi/spi.c#L4149   => spi framework check failed.

Solution:
Don't pollute spi transfer data since the data may re-use and change the transfer length and tx/rx buffer. (ex: tpm-spi)


Test with Infineon TPM SLB9670 OK.