### PR TITLE
arm64: dts: npcm8xx: Disable NPCM PCIe-RC by default

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -213,6 +213,7 @@
 			interrupts = <GIC_SPI 127 IRQ_TYPE_LEVEL_HIGH>;
 			interrupt-map-mask = <0 0 0 7>;
 			interrupt-map = <0 0 0 1 &gic GIC_SPI 127 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
 		};
 
 		ehci1: usb@f0828100 {


### PR DESCRIPTION
Disable NPCM PCIe-RC by default.