### PR TITLE
arm64: dts: npcm8xx: correct pinctrl unit-address

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -1111,7 +1111,7 @@
 		};
 	};
 
-	pinctrl: pinctrl@f0800260 {
+	pinctrl: pinctrl@f0010000 {
 		compatible = "nuvoton,npcm845-pinctrl", "syscon", "simple-mfd";
 		ranges = <0x0 0x0 0xf0010000 0x8000>;
 		#address-cells = <1>;

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-pincfg-evb.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-pincfg-evb.dtsi
@@ -2,7 +2,7 @@
 // Copyright (c) 2018 Nuvoton Technology
 
 / {
-	pinctrl: pinctrl@f0800260 {
+	pinctrl: pinctrl@f0010000 {
 		pin4_slew: pin4_slew {
 			pins = "GPIO4/IOX2_DI/SMB1D_SDA";
 			slew-rate = <1>;


### PR DESCRIPTION
The unit-address must match the first address specified in the reg property of the node.

Before:
root@evb-npcm845:~# gpiodetect
gpiochip0 [/pinctrl@f0800260/gpio@f0010000] (32 lines) gpiochip1 [/pinctrl@f0800260/gpio@f0011000] (32 lines) gpiochip2 [/pinctrl@f0800260/gpio@f0012000] (32 lines) gpiochip3 [/pinctrl@f0800260/gpio@f0013000] (32 lines) gpiochip4 [/pinctrl@f0800260/gpio@f0014000] (32 lines) gpiochip5 [/pinctrl@f0800260/gpio@f0015000] (32 lines) gpiochip6 [/pinctrl@f0800260/gpio@f0016000] (32 lines) gpiochip7 [/pinctrl@f0800260/gpio@f0017000] (32 lines) gpiochip8 [f0102000.sgpio] (128 lines)

After:
root@evb-npcm845:~# gpiodetect
gpiochip0 [/pinctrl@f0010000/gpio@f0010000] (32 lines) gpiochip1 [/pinctrl@f0010000/gpio@f0011000] (32 lines) gpiochip2 [/pinctrl@f0010000/gpio@f0012000] (32 lines) gpiochip3 [/pinctrl@f0010000/gpio@f0013000] (32 lines) gpiochip4 [/pinctrl@f0010000/gpio@f0014000] (32 lines) gpiochip5 [/pinctrl@f0010000/gpio@f0015000] (32 lines) gpiochip6 [/pinctrl@f0010000/gpio@f0016000] (32 lines) gpiochip7 [/pinctrl@f0010000/gpio@f0017000] (32 lines) gpiochip8 [f0102000.sgpio] (128 lines)