### PR TITLE
iio: adc: npcm: add reset method to fix get value failed

### DIFF
--- a/drivers/iio/adc/npcm_adc.c
+++ b/drivers/iio/adc/npcm_adc.c
@@ -447,6 +447,15 @@ static int npcm_adc_probe(struct platform_device *pdev)
 		goto err_disable_clk;
 	}
 
+	if (of_device_is_compatible(dev->of_node, "nuvoton,npcm845-adc")) {
+		reg_con = ioread32(info->regs + NPCM_ADCCON);
+		iowrite32(reg_con | NPCM_ADCCON_ADC_EN, info->regs + NPCM_ADCCON);
+		reset_control_assert(info->reset);
+		udelay(1);
+		reset_control_deassert(info->reset);
+		udelay(1);
+	}
+
 	ret = devm_request_irq(&pdev->dev, irq, npcm_adc_isr, 0,
 			       "NPCM_ADC", indio_dev);
 	if (ret < 0) {


### PR DESCRIPTION
Add a reset method to handle the issue
of not being able to obtain ADC values at some marginal timings.