### PR TITLE
iio: adc: npcm: remove reset method flag

### DIFF
--- a/drivers/iio/adc/npcm_adc.c
+++ b/drivers/iio/adc/npcm_adc.c
@@ -448,14 +448,12 @@ static int npcm_adc_probe(struct platform_device *pdev)
 		goto err_disable_clk;
 	}
 
-	if (of_device_is_compatible(dev->of_node, "nuvoton,npcm845-adc")) {
-		reg_con = ioread32(info->regs + NPCM_ADCCON);
-		iowrite32(reg_con | NPCM_ADCCON_ADC_EN, info->regs + NPCM_ADCCON);
-		reset_control_assert(info->reset);
-		udelay(1);
-		reset_control_deassert(info->reset);
-		udelay(1);
-	}
+	reg_con = ioread32(info->regs + NPCM_ADCCON);
+	iowrite32(reg_con | NPCM_ADCCON_ADC_EN, info->regs + NPCM_ADCCON);
+	reset_control_assert(info->reset);
+	udelay(1);
+	reset_control_deassert(info->reset);
+	udelay(1);
 
 	ret = devm_request_irq(&pdev->dev, irq, npcm_adc_isr, 0,
 			       "NPCM_ADC", indio_dev);


### PR DESCRIPTION
Remove the flag to allow the method to work on both NPCM7xx and NPCM8xx.