### PR TITLE
ipmi: ssif_bmc: Enable the slave when a timeout occurs

### DIFF
--- a/drivers/char/ipmi/ssif_bmc.c
+++ b/drivers/char/ipmi/ssif_bmc.c
@@ -324,6 +324,8 @@ static void response_timeout(struct timer_list *t)
 		ssif_bmc->aborting = true;
 	}
 
+	if (ssif_bmc->set_ssif_bmc_status)
+		ssif_bmc->set_ssif_bmc_status(ssif_bmc->client, SSIF_BMC_READY);
 	spin_unlock_irqrestore(&ssif_bmc->lock, flags);
 }
 


### PR DESCRIPTION
After handling a request timeout,
the slave state will not be changed back to ready.