### PR TITLE
mtd: core: add sync between read/write and unbind device

### DIFF
--- a/drivers/mtd/mtdcore.c
+++ b/drivers/mtd/mtdcore.c
@@ -1205,6 +1205,9 @@ int __get_mtd_device(struct mtd_info *mtd)
 	struct mtd_info *master = mtd_get_master(mtd);
 	int err;
 
+	if (master->mtd_event_remove)
+		return -ENODEV;
+
 	if (!try_module_get(master->owner))
 		return -ENODEV;
 

--- a/drivers/mtd/spi-nor/core.c
+++ b/drivers/mtd/spi-nor/core.c
@@ -18,6 +18,7 @@
 #include <linux/slab.h>
 
 #include <linux/mtd/mtd.h>
+#include <linux/of_device.h>
 #include <linux/of_platform.h>
 #include <linux/sched/task_stack.h>
 #include <linux/spi/flash.h>
@@ -43,6 +44,9 @@
 
 #define SPI_NOR_SRST_SLEEP_MIN 200
 #define SPI_NOR_SRST_SLEEP_MAX 400
+
+static int spi_nor_remove_notifier_call(struct notifier_block *nb,
+					unsigned long event, void *data);
 
 /**
  * spi_nor_get_cmd_ext() - Get the command opcode extension based on the
@@ -1084,6 +1088,10 @@ int spi_nor_lock_and_prep(struct spi_nor *nor)
 			return ret;
 		}
 	}
+
+	if (nor->mtd.mtd_event_remove)
+		return -ENODEV;
+
 	return ret;
 }
 
@@ -3180,6 +3188,11 @@ static int spi_nor_probe(struct spi_mem *spimem)
 	if (ret)
 		return ret;
 
+	if (!nor->spi_nor_remove_nb.notifier_call) {
+		nor->spi_nor_remove_nb.notifier_call = spi_nor_remove_notifier_call;
+		bus_register_notifier(&spi_bus_type, &nor->spi_nor_remove_nb);
+	}
+
 	return mtd_device_register(&nor->mtd, data ? data->parts : NULL,
 				   data ? data->nr_parts : 0);
 }
@@ -3189,6 +3202,9 @@ static int spi_nor_remove(struct spi_mem *spimem)
 	struct spi_nor *nor = spi_mem_get_drvdata(spimem);
 
 	spi_nor_restore(nor);
+
+	bus_unregister_notifier(&spi_bus_type, &nor->spi_nor_remove_nb);
+	memset(&nor->spi_nor_remove_nb, 0, sizeof(nor->spi_nor_remove_nb));
 
 	/* Clean up MTD stuff. */
 	return mtd_device_unregister(&nor->mtd);
@@ -3267,6 +3283,37 @@ static const struct of_device_id spi_nor_of_table[] = {
 	{ /* sentinel */ },
 };
 MODULE_DEVICE_TABLE(of, spi_nor_of_table);
+
+static int spi_nor_remove_notifier_call(struct notifier_block *nb,
+				    unsigned long event, void *data)
+{
+	struct device *dev = data;
+	struct spi_device *spi;
+	struct spi_mem *mem;
+	struct spi_nor *nor;
+
+	if (!of_match_device(spi_nor_of_table, dev))
+		return 0;
+
+	switch (event) {
+	case BUS_NOTIFY_DEL_DEVICE:
+	case BUS_NOTIFY_UNBIND_DRIVER:
+		spi = to_spi_device(dev);
+		mem = spi_get_drvdata(spi);
+		if (!mem)
+			return NOTIFY_DONE;
+		nor = spi_mem_get_drvdata(mem);
+
+		mutex_lock(&nor->lock);
+		nor->mtd.mtd_event_remove = true;
+		mutex_unlock(&nor->lock);
+		msleep(300);
+
+		break;
+	}
+
+	return NOTIFY_DONE;
+}
 
 /*
  * REVISIT: many of these chips have deep power-down modes, which

--- a/include/linux/mtd/mtd.h
+++ b/include/linux/mtd/mtd.h
@@ -290,6 +290,7 @@ struct mtd_info {
 	/* Kernel-only stuff starts here. */
 	const char *name;
 	int index;
+	bool mtd_event_remove;
 
 	/* OOB layout description */
 	const struct mtd_ooblayout_ops *ooblayout;

--- a/include/linux/mtd/spi-nor.h
+++ b/include/linux/mtd/spi-nor.h
@@ -404,6 +404,7 @@ struct spi_nor {
 	} dirmap;
 
 	void *priv;
+	struct notifier_block spi_nor_remove_nb;
 };
 
 static inline void spi_nor_set_flash_node(struct spi_nor *nor,


### PR DESCRIPTION
When unbind is running, the memory allocated to spi controller and mtd device is freed during unbinding, but open/close and reading device are still running, if the reading process get read lock and start excuting, there will be above illegal memory access.

Register a spi bus notifier which will called before unbind process free device memory, and add a new member mtd_event_remove to block mtd open/read, then wait for the running task to be finished, then free memory is safe to be run.

When unbinding mtd device or spi controller with a high frequency reading to /proc/mtd, there will be call trace as below:

$ cd /sys/bus/platform/devices/c0000000.spi/driver $ while true; do cat /proc/mtd; sleep 1; done &
$ while true; do echo -n "c0000000.spi" > unbind;
  echo -n "c0000000.spi" > bind; sleep 1; done &

Hardware name: Nuvoton npcm845 Development Board (Device Tree) (DT)
pstate: 60000005 (nZCv daif -PAN -UAO -TCO -DIT -SSBS BTYPE=--)
pc : sysfs_remove_group+0x94/0xa0
lr : sysfs_remove_group+0x94/0xa0
sp : ffffffc00dc9ba80

Call trace:
 sysfs_remove_group+0x94/0xa0
 dpm_sysfs_remove+0x5c/0xb8
 device_del+0xa8/0x3bc
 device_unregister+0x2c/0x80
 device_destroy+0x50/0x84
 mtd_release+0x40/0x58
 device_release+0x34/0x98
 kobject_put+0xd4/0x230
 device_unregister+0x38/0x80
 mtd_device_release+0x34/0x80
 __put_mtd_device+0x70/0xb4
 put_mtd_device+0x30/0x48
 mtdchar_close+0x40/0x9c
 __fput+0x70/0x220
 ____fput+0x10/0x20
 task_work_run+0xcc/0x134
 do_notify_resume+0x71c/0x1260
 el0_svc+0xa0/0xb0
 el0t_64_sync_handler+0x108/0x114
 el0t_64_sync+0x1a0/0x1a4
---[ end trace 5f2704ccc94a3163 ]---
Unable to handle kernel NULL pointer dereference at virtual address

Link: https://lore.kernel.org/lkml/20250325133954.3699535-1-liwei.song.lsong@gmail.com/T/