### PR TITLE
pinctrl: nuvoton: npcm8xx: fix memory leak in dt_free_map

### DIFF
--- a/drivers/pinctrl/nuvoton/pinctrl-npcm8xx.c
+++ b/drivers/pinctrl/nuvoton/pinctrl-npcm8xx.c
@@ -2001,18 +2001,12 @@ static int npcm8xx_dt_node_to_map(struct pinctrl_dev *pctldev,
 					      PIN_MAP_TYPE_INVALID);
 }
 
-static void npcm8xx_dt_free_map(struct pinctrl_dev *pctldev,
-				struct pinctrl_map *map, u32 num_maps)
-{
-	kfree(map);
-}
-
 static const struct pinctrl_ops npcm8xx_pinctrl_ops = {
 	.get_groups_count = npcm8xx_get_groups_count,
 	.get_group_name = npcm8xx_get_group_name,
 	.get_group_pins = npcm8xx_get_group_pins,
 	.dt_node_to_map = npcm8xx_dt_node_to_map,
-	.dt_free_map = npcm8xx_dt_free_map,
+	.dt_free_map = pinctrl_utils_free_map,
 };
 
 static int npcm8xx_get_functions_count(struct pinctrl_dev *pctldev)


### PR DESCRIPTION
When CONFIG_DEBUG_KMEMLEAK is enabled, a memory leak is detected upon freeing the pinmux map.

The custom npcm8xx_dt_free_map() only performs a pure kfree() on the map array. This leaks the nested configuration structures (configs) allocated during map creation.

Fix this by replacing it with the generic pinctrl_utils_free_map(), which correctly iterates over the map entries and frees all associated configuration structures before freeing the map.

Memory leak detection:
unreferenced object 0xffffff800a125b00 (size 128):
  comm "swapper/0", pid 1, jiffies 4294892649 (age 192.136s)
  hex dump (first 32 bytes):
    18 01 00 00 00 00 00 00 00 00 00 14 00 00 00 14  ................
    00 00 00 14 00 00 00 14 00 00 00 14 00 00 00 14  ................
  backtrace:
    [<00000000be2d36ae>] __kmem_cache_alloc_node+0x2a8/0x3fc
    [<0000000017ecbe4f>] __kmalloc_node_track_caller+0x44/0x70
    [<00000000ebb00cac>] kmemdup+0x3c/0x70
    [<0000000017f31234>] pinctrl_utils_add_map_configs+0x4c/0xf0
    [<0000000049156d08>] pinconf_generic_dt_subnode_to_map+0x168/0x270
    [<00000000b9ec6ccb>] pinconf_generic_dt_node_to_map+0x60/0x120
    [<00000000b7b370dc>] npcm8xx_dt_node_to_map+0x14/0x20
    [<000000007f1fdb48>] pinctrl_dt_to_map+0x268/0x430
    [<00000000fa385fa2>] create_pinctrl+0x68/0x3c0
    [<000000003531b97f>] pinctrl_get+0xcc/0x150
    [<000000007fa2e58c>] devm_pinctrl_get+0x48/0x90
    [<00000000f4dea3c5>] pinctrl_bind_pins+0x58/0x280
    [<00000000f999604f>] really_probe+0x68/0x404
    [<00000000b6cbeaa4>] __driver_probe_device+0x88/0x15c
    [<0000000097696e17>] driver_probe_device+0x40/0xe0
    [<00000000edcae6e1>] __driver_attach+0x128/0x1e4