### PR TITLE
arm64: dts: npcm8xx: set slew rate for siox1

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-evb.dts
@@ -687,6 +687,10 @@
 			&jtag2_pins
 			&lpc_pins
 			&spix_pins
+			&pin0_slew
+			&pin1_slew
+			&pin2_slew
+			&pin3_slew
 			&pin4_slew
 			&pin5_slew
 			&pin6_slew

--- a/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-pincfg-evb.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-npcm845-pincfg-evb.dtsi
@@ -3,6 +3,22 @@
 
 / {
 	pinctrl: pinctrl@f0010000 {
+		pin0_slew: pin0_slew {
+			pins = "GPIO0/IOX1_DI/SMB6C_SDA/SMB18_SDA";
+			slew-rate = <1>;
+		};
+		pin1_slew: pin1_slew {
+			pins = "GPIO1/IOX1_LD/SMB6C_SCL/SMB18_SCL";
+			slew-rate = <1>;
+		};
+		pin2_slew: pin2_slew {
+			pins = "GPIO2/IOX1_CK/SMB6B_SDA/SMB17_SDA";
+			slew-rate = <1>;
+		};
+		pin3_slew: pin3_slew {
+			pins = "GPIO3/IOX1_DO/SMB6B_SCL/SMB17_SCL";
+			slew-rate = <1>;
+		};
 		pin4_slew: pin4_slew {
 			pins = "GPIO04/IOX2_DI/SMB1D_SDA";
 			slew-rate = <1>;


### PR DESCRIPTION
Set the slew rate for SIOX1 to handle a triangular waveform.