### PR TITLE
Edac 515

### DIFF
--- a/drivers/edac/npcm_edac.c
+++ b/drivers/edac/npcm_edac.c
@@ -311,13 +311,6 @@ static int setup_irq(struct mem_ctl_info *mci, struct platform_device *pdev)
 		return irq;
 	}
 
-	ret = devm_request_irq(&pdev->dev, irq, edac_ecc_isr, 0,
-			       dev_name(&pdev->dev), mci);
-	if (ret < 0) {
-		edac_printk(KERN_ERR, EDAC_MOD_NAME, "failed to request IRQ\n");
-		return ret;
-	}
-
 	/* enable the functional group of ECC and mask the others */
 	regmap_write(npcm_regmap, pdata->ctl_int_mask_master,
 		     pdata->int_mask_master_non_ecc_mask);
@@ -325,6 +318,13 @@ static int setup_irq(struct mem_ctl_info *mci, struct platform_device *pdev)
 	if (pdata->chip == NPCM8XX_CHIP)
 		regmap_write(npcm_regmap, pdata->ctl_int_mask_ecc,
 			     pdata->int_mask_ecc_non_event_mask);
+
+	ret = devm_request_irq(&pdev->dev, irq, edac_ecc_isr, 0,
+			       dev_name(&pdev->dev), mci);
+	if (ret < 0) {
+		edac_printk(KERN_ERR, EDAC_MOD_NAME, "failed to request IRQ\n");
+		return ret;
+	}
 
 	return 0;
 }


### PR DESCRIPTION
The interrupt handler was registered via devm_request_irq() before the interrupt mask registers were configured. This created a window where a stale pending interrupt (e.g., from the other groups) could be delivered to the ISR before the master interrupt mask had been programmed to allow only the ECC group.