### PR TITLE
arm: dts: nuvoton: align olympus DTS to 6.1 and keep 6.12 BPC

### DIFF
--- a/arch/arm/boot/dts/nuvoton/nuvoton-common-npcm7xx.dtsi
+++ b/arch/arm/boot/dts/nuvoton/nuvoton-common-npcm7xx.dtsi
@@ -5,11 +5,17 @@
 #include <dt-bindings/interrupt-controller/arm-gic.h>
 #include <dt-bindings/clock/nuvoton,npcm7xx-clock.h>
 #include <dt-bindings/reset/nuvoton,npcm7xx-reset.h>
+#include <dt-bindings/gpio/gpio.h>
 
 / {
 	#address-cells = <1>;
 	#size-cells = <1>;
 	interrupt-parent = <&gic>;
+
+	memory {
+		device_type = "memory";
+		reg = <0 0>;
+	};
 
 	/* external reference clock */
 	clk_refclk: clk_refclk {
@@ -65,6 +71,11 @@
 		interrupt-parent = <&gic>;
 		ranges = <0x0 0xf0000000 0x00900000>;
 
+		fuse: fuse@18a000 {
+			compatible = "nuvoton,npcm750-fuse", "syscon", "simple-mfd";
+			reg = <0x18a000 0x1000>;
+		};
+
 		scu: scu@3fe000 {
 			compatible = "arm,cortex-a9-scu";
 			reg = <0x3fe000 0x1000>;
@@ -99,11 +110,6 @@
 		};
 	};
 
-	udc0_phy: usb-phy {
-		compatible = "usb-nop-xceiv";
-		#phy-cells = <0>;
-	};
-
 	ahb {
 		#address-cells = <1>;
 		#size-cells = <1>;
@@ -127,14 +133,7 @@
 			clocks = <&clk_refclk>, <&clk_sysbypck>, <&clk_mcbypck>;
 		};
 
-		mc: memory-controller@f0824000 {
-			compatible = "nuvoton,npcm750-memory-controller";
-			reg = <0xf0824000 0x1000>;
-			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
-			status = "disabled";
-		};
-
-		gmac0: ethernet@f0802000 {
+		gmac0: eth@f0802000 {
 			device_type = "network";
 			compatible = "snps,dwmac";
 			reg = <0xf0802000 0x2000>;
@@ -148,6 +147,8 @@
 					&rg1mdio_pins>;
 			status = "disabled";
 		};
+
+
 
 		emc0: eth@f0825000 {
 			device_type = "network";
@@ -165,40 +166,10 @@
 			status = "disabled";
 		};
 
-		sdmmc: mmc@f0842000 {
-			compatible = "nuvoton,npcm750-sdhci";
-			status = "disabled";
-			reg = <0xf0842000 0x200>;
-			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL_HIGH>;
-			clocks =  <&clk NPCM7XX_CLK_AHB>;
-			clock-names = "clk_mmc";
-			pinctrl-names = "default";
-			pinctrl-0 = <&mmc8_pins
-					&mmc_pins>;
-		};
-
-		sdhci: mmc@f0840000 {
-			compatible = "nuvoton,npcm750-sdhci";
-			status = "disabled";
-			reg = <0xf0840000 0x200>;
-			interrupts = <GIC_SPI 27 IRQ_TYPE_LEVEL_HIGH>;
-			clocks =  <&clk NPCM7XX_CLK_AHB>;
-			clock-names = "clk_sdhc";
-			pinctrl-names = "default";
-			pinctrl-0 = <&sd1_pins>;
-		};
-
 		ehci1: usb@f0806000 {
 			compatible = "nuvoton,npcm750-ehci";
 			reg = <0xf0806000 0x1000>;
 			interrupts = <GIC_SPI 61 IRQ_TYPE_LEVEL_HIGH>;
-			status = "disabled";
-		};
-
-		ohci1: usb@f0807000 {
-			compatible = "generic-ohci";
-			reg = <0xf0807000 0x1000>;
-			interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
 
@@ -226,6 +197,54 @@
 			status = "disabled";
 		};
 
+		ohci1: ohci@f0807000 {
+			compatible = "nuvoton,npcm750-ohci";
+			reg = <0xf0807000 0x1000>;
+			interrupts = <GIC_SPI 62 IRQ_TYPE_LEVEL_HIGH>;
+			status = "disabled";
+		};
+
+		sdhci0: sdhci@f0842000 {
+			compatible = "nuvoton,npcm750-sdhci";
+			status = "disabled";
+			reg = <0xf0842000 0x200>;
+			interrupts = <GIC_SPI 26 IRQ_TYPE_LEVEL_HIGH>;
+			clocks =  <&clk NPCM7XX_CLK_AHB>;      /*, <&clk_xin>;*/
+			clock-names = "clk_mmc";               /* ,"clk_xin"; */
+			pinctrl-names = "default";
+			pinctrl-0 = <&mmc8_pins
+				     &mmc_pins>;
+		};
+
+		sdhci1: sdhci@f0840000 {
+			compatible = "nuvoton,npcm750-sdhci";
+			status = "disabled";
+			reg = <0xf0840000 0x200>;
+			interrupts = <GIC_SPI 27 IRQ_TYPE_LEVEL_HIGH>;
+			clocks =  <&clk NPCM7XX_CLK_AHB>;      /*, <&clk_xin>;*/
+			clock-names = "clk_sdhc";              /* ,"clk_xin"; */
+			pinctrl-names = "default";
+			pinctrl-0 = <&sd1_pins>;
+		};
+
+		aes:aes@f0858000 {
+			compatible = "nuvoton,npcm750-aes";
+			reg = <0xf0858000 0x1000>;
+			status = "disabled";
+			clocks = <&clk NPCM7XX_CLK_AHB>;
+			clock-names = "clk_ahb";
+		};
+
+		sha:sha@f085a000 {
+			compatible = "nuvoton,npcm750-sha";
+			reg = <0xf085a000 0x1000>;
+			status = "disabled";
+			clocks = <&clk NPCM7XX_CLK_AHB>;
+			clock-names = "clk_ahb";
+		};
+
+
+
 		fiux: spi@fb001000 {
 			compatible = "nuvoton,npcm750-fiu";
 			#address-cells = <1>;
@@ -237,70 +256,55 @@
 			status = "disabled";
 		};
 
-		udc5: usb@f0835000 {
-			compatible = "nuvoton,npcm750-udc";
-			reg = <0xf0835000 0x1000
-			       0xfffd2800 0x800>;
-			interrupts = <GIC_SPI 56 IRQ_TYPE_LEVEL_HIGH>;
-			clocks = <&clk NPCM7XX_CLK_SU>;
-			clock-names = "clk_usb_bridge";
-			phys = <&udc0_phy>;
-			phy_type = "utmi_wide";
-			dr_mode = "peripheral";
+		mc: memory-controller@f0824000 {
+			compatible = "nuvoton,npcm750-memory-controller";
+			reg = <0xf0824000 0x1000>;
+			interrupts = <GIC_SPI 25 IRQ_TYPE_LEVEL_HIGH>;
 			status = "disabled";
 		};
 
-		udc6: usb@f0836000 {
-			compatible = "nuvoton,npcm750-udc";
-			reg = <0xf0836000 0x1000
-			       0xfffd3000 0x800>;
-			interrupts = <GIC_SPI 57 IRQ_TYPE_LEVEL_HIGH>;
-			clocks = <&clk NPCM7XX_CLK_SU>;
-			clock-names = "clk_usb_bridge";
-			phys = <&udc0_phy>;
-			phy_type = "utmi_wide";
-			dr_mode = "peripheral";
-			status = "disabled";
-		};
-
-		udc7: usb@f0837000 {
-			compatible = "nuvoton,npcm750-udc";
-			reg = <0xf0837000 0x1000
-			       0xfffd3800 0x800>;
-			interrupts = <GIC_SPI 58 IRQ_TYPE_LEVEL_HIGH>;
-			clocks = <&clk NPCM7XX_CLK_SU>;
-			clock-names = "clk_usb_bridge";
-			phys = <&udc0_phy>;
-			phy_type = "utmi_wide";
-			dr_mode = "peripheral";
-			status = "disabled";
-		};
-
-		udc8: usb@f0838000 {
-			compatible = "nuvoton,npcm750-udc";
-			reg = <0xf0838000 0x1000
-			       0xfffd4000 0x800>;
-			interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL_HIGH>;
-			clocks = <&clk NPCM7XX_CLK_SU>;
-			clock-names = "clk_usb_bridge";
-			phys = <&udc0_phy>;
-			phy_type = "utmi_wide";
-			dr_mode = "peripheral";
-			status = "disabled";
-		};
-
-		udc9: usb@f0839000 {
-			compatible = "nuvoton,npcm750-udc";
-			reg = <0xf0839000 0x1000
-			       0xfffd4800 0x800>;
-			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL_HIGH>;
-			clocks = <&clk NPCM7XX_CLK_SU>;
-			clock-names = "clk_usb_bridge";
+		pcie: pcie@e1000000 {
+			compatible = "nuvoton,npcm750-pcie";
+			device_type = "pci";
+			reg = <0xE1000000 0x1000>,
+				<0xE8000000 0x1000>;	
+			bus-range = <0x0 0xF>;
+			#address-cells = <3>;
+			#size-cells = <2>;
+			#interrupt-cells = <1>;
+ 			ranges = <0x01000000 0 0xe9000000 0xe9000000 0 0x00010000
+				  0x02000000 0 0xea000000 0xea000000 0 0x02000000>;
+ 			resets = <&rstc NPCM7XX_RESET_IPSRST3 NPCM7XX_RESET_PCIE_RC>;
+			interrupts = <GIC_SPI 127 IRQ_TYPE_LEVEL_HIGH>;
+			interrupt-map-mask = <0 0 0 7>;
+			interrupt-map = <0 0 0 1 &gic GIC_SPI 127 IRQ_TYPE_LEVEL_HIGH>;
 			nuvoton,sysgcr = <&gcr>;
-			phys = <&udc0_phy>;
-			phy_type = "utmi_wide";
-			dr_mode = "peripheral";
+		};
+
+		vcd: vcd@f0810000 {
+			compatible = "nuvoton,npcm750-vcd";
+			reg = <0xf0810000 0x10000>;
+			interrupts = <GIC_SPI 22 IRQ_TYPE_LEVEL_HIGH>;
+			resets = <&rstc NPCM7XX_RESET_IPSRST2 NPCM7XX_RESET_VCD>;
+			nuvoton,sysgcr = <&gcr>;
+			nuvoton,sysgfxi = <&gfxi>;
+			nuvoton,ece = <&ece>;
 			status = "disabled";
+		};
+
+		ece: video-codec@f0820000 {
+			compatible = "nuvoton,npcm750-ece";
+			reg = <0xf0820000 0x2000>;
+			interrupts = <GIC_SPI 24 IRQ_TYPE_LEVEL_HIGH>;
+			resets = <&rstc NPCM7XX_RESET_IPSRST2 NPCM7XX_RESET_ECE>;
+			status = "disabled";
+		};
+		pcimbox: pcimbox@f0848000 {
+			compatible = "nuvoton,npcm750-pci-mbox",
+					"simple-mfd", "syscon";
+			reg = <0xf084C000 0x8
+				0xf0848000 0x3F00>;
+			interrupts = <GIC_SPI 8 IRQ_TYPE_LEVEL_HIGH>;
 		};
 
 		apb {
@@ -344,13 +348,38 @@
 				};
 			};
 
-			peci: peci-controller@f0100000 {
-				compatible = "nuvoton,npcm750-peci";
-				reg = <0xf0100000 0x200>;
-				interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL_HIGH>;
-				clocks = <&clk NPCM7XX_CLK_APB3>;
-				cmd-timeout-ms = <1000>;
-				status = "disabled";
+			lpc_host: lpc_host@7000 {
+				compatible = "nuvoton,npcm750-lpc-host",
+						"simple-mfd", "syscon";
+				reg = <0x7000 0x60>;
+
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x0 0x7000 0x60>;
+
+				lpc_bpc: lpc_bpc@40 {
+					compatible = "nuvoton,npcm-bpc";
+					reg = <0x40 0x20>;
+					interrupts = <GIC_SPI 9 IRQ_TYPE_LEVEL_HIGH>;
+					status = "disabled";
+				};
+			};
+
+			peci: peci-bus@100000 {
+				compatible = "simple-bus";
+				#address-cells = <1>;
+				#size-cells = <1>;
+				ranges = <0x0 0x100000 0x200>;
+
+				peci0: peci-bus@0 {
+					compatible = "nuvoton,npcm750-peci";
+					reg = <0x0 0x200>;
+					#address-cells = <1>;
+					#size-cells = <0>;
+					interrupts = <GIC_SPI 6 IRQ_TYPE_LEVEL_HIGH>;
+					clocks = <&clk NPCM7XX_CLK_APB3>;
+					status = "disabled";
+				};
 			};
 
 			spi0: spi@200000 {
@@ -460,6 +489,35 @@
 				interrupts = <GIC_SPI 0 IRQ_TYPE_LEVEL_HIGH>;
 				clocks = <&clk NPCM7XX_CLK_ADC>;
 				resets = <&rstc NPCM7XX_RESET_IPSRST1 NPCM7XX_RESET_ADC>;
+				syscon = <&fuse>;
+				status = "disabled";
+			};
+
+			sgpio1: sgpio@101000 {
+				compatible = "nuvoton,npcm750-sgpio";
+				reg = <0x101000 0x200>;
+				clocks = <&clk NPCM7XX_CLK_APB3>;
+				interrupts = <GIC_SPI 19 IRQ_TYPE_LEVEL_HIGH>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&iox1_pins>;
+				nuvoton,input-ngpios = <64>;
+				nuvoton,output-ngpios = <64>;
+				status = "disabled";
+			};
+
+			sgpio2: sgpio@102000 {
+				compatible = "nuvoton,npcm750-sgpio";
+				reg = <0x102000 0x200>;
+				clocks = <&clk NPCM7XX_CLK_APB3>;
+				interrupts = <GIC_SPI 20 IRQ_TYPE_LEVEL_HIGH>;
+				gpio-controller;
+				#gpio-cells = <2>;
+				pinctrl-names = "default";
+				pinctrl-0 = <&iox2_pins>;
+				nuvoton,input-ngpios = <64>;
+				nuvoton,output-ngpios = <64>;
 				status = "disabled";
 			};
 
@@ -494,6 +552,15 @@
 						&fanin12_pins &fanin13_pins
 						&fanin14_pins &fanin15_pins>;
 				status = "disabled";
+			};
+
+			otp:otp@189000 {
+				compatible = "nuvoton,npcm750-otp";
+				reg = <0x189000 0x1000
+					   0x18a000 0x1000>;
+				status = "disabled";
+				clocks = <&clk NPCM7XX_CLK_APB4>;
+				clock-names = "clk_apb4";
 			};
 
 			i2c0: i2c@80000 {
@@ -686,6 +753,12 @@
 				pinctrl-names = "default";
 				pinctrl-0 = <&smb15_pins>;
 				status = "disabled";
+			};
+
+			gfxi: gfxi@e000 {
+				compatible = "nuvoton,npcm750-gfxi", "syscon",
+					     "simple-mfd";
+				reg = <0xe000 0x100>;
 			};
 		};
 	};

--- a/arch/arm/boot/dts/nuvoton/nuvoton-npcm750-runbmc-olympus-pincfg.dtsi
+++ b/arch/arm/boot/dts/nuvoton/nuvoton-npcm750-runbmc-olympus-pincfg.dtsi
@@ -78,6 +78,22 @@
 			bias-disable;
 			output-low;
 		};
+		gpio17_pins: gpio17-pins {
+			pins = "GPIO17/PSPI2DI/SMB4DEN";
+			bias-disable;
+			input-enable;
+		};
+		gpio18o_pins: gpio18o-pins {
+			pins = "GPIO18/PSPI2D0/SMB4BSDA";
+			bias-disable;
+			output-high;
+		};
+		gpio19ol_pins: gpio19ol-pins {
+			pins = "GPIO19/PSPI2CK/SMB4BSCL";
+			bias-disable;
+			output-low;
+		};
+
 		gpio20_pins: gpio20-pins {
 			pins = "GPIO20/SMB4CSDA/SMB15SDA";
 			bias-disable;

--- a/arch/arm/boot/dts/nuvoton/nuvoton-npcm750-runbmc-olympus.dts
+++ b/arch/arm/boot/dts/nuvoton/nuvoton-npcm750-runbmc-olympus.dts
@@ -14,11 +14,23 @@
 	compatible = "nuvoton,npcm750";
 
 	aliases {
+		ethernet0 = &emc0;
 		ethernet1 = &gmac0;
 		serial0 = &serial0;
 		serial1 = &serial1;
 		serial2 = &serial2;
 		serial3 = &serial3;
+		udc0 = &udc0;
+		udc1 = &udc1;
+		udc2 = &udc2;
+		udc3 = &udc3;
+		udc4 = &udc4;
+		udc5 = &udc5;
+		udc6 = &udc6;
+		udc7 = &udc7;
+		udc8 = &udc8;
+		udc9 = &udc9;
+		emmc0 = &sdhci0;
 		i2c0 = &i2c0;
 		i2c1 = &i2c1;
 		i2c2 = &i2c2;
@@ -58,6 +70,7 @@
 		heartbeat {
 		label = "heartbeat";
 			gpios = <&gpio3 14 1>;
+			linux,default-trigger = "timer";
 		};
 
 		identify {
@@ -65,6 +78,25 @@
 			gpios = <&gpio3 15 1>;
 		};
 	};
+
+	led_ctrl {
+		compatible = "cpt, led";
+		status = "okay";
+		gpio125-en = <&gpio3 29 1>;
+	};
+
+	mcu_flash {
+		compatible = "nuvoton,npcm750-mcu-flash";
+		status = "okay";
+		#address-cells = <1>;
+		#size-cells = <1>;
+		dev-num = <0>;    /* /dev/mcu0 */
+		smb-offset = <6>; /* SMBSEL offset of MFSEL3 */
+		mcu-gpios = <&gpio6 30 GPIO_ACTIVE_HIGH>,     /* GPIO222/PROG_CLK, Output */
+			<&gpio6 31 GPIO_ACTIVE_HIGH>,     /* GPIO223/PROG_MOSI Output */
+			<&gpio1 6 GPIO_ACTIVE_HIGH>,      /* GPIO38/PROG_MISO, Input  */
+			<&gpio1 5 GPIO_ACTIVE_HIGH>;       /* GPIO37/RESET#, Output    */
+    };
 
 	jtag {
 		compatible = "nuvoton,npcm750-jtag";
@@ -106,21 +138,21 @@
 		#size-cells = <1>;
 		reg = <0>;
 		spi-rx-bus-width = <2>;
+		spi-tx-bus-width = <2>;
 
-		partitions {
+		partitions@80000000 {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			bmc@0 {
+			bmc@0{
 				label = "bmc";
-				reg = <0x000000 0x2000000>;
+				reg = <0x000000 0x4000000>;
 			};
 			u-boot@0 {
 				label = "u-boot";
-				reg = <0x0000000 0x80000>;
-				read-only;
+				reg = <0x0000000 0xc0000>;
 			};
-			u-boot-env@100000 {
+			u-boot-env@100000{
 				label = "u-boot-env";
 				reg = <0x00100000 0x40000>;
 			};
@@ -130,11 +162,11 @@
 			};
 			rofs@800000 {
 				label = "rofs";
-				reg = <0x800000 0x1500000>;
+				reg = <0x800000 0x3500000>;
 			};
 			rwfs@1d00000 {
 				label = "rwfs";
-				reg = <0x1d00000 0x300000>;
+				reg = <0x3d00000 0x300000>;
 			};
 		};
 	};
@@ -144,9 +176,10 @@
 		#address-cells = <1>;
 		#size-cells = <1>;
 		reg = <1>;
-		npcm,fiu-rx-bus-width = <2>;
+		spi-rx-bus-width = <2>;
+		spi-tx-bus-width = <2>;
 
-		partitions {
+		partitions@88000000 {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
@@ -172,18 +205,15 @@
 		#size-cells = <1>;
 		reg = <0>;
 		spi-rx-bus-width = <2>;
+		spi-tx-bus-width = <2>;
 
-		partitions {
+		partitions@A0000000 {
 			compatible = "fixed-partitions";
 			#address-cells = <1>;
 			#size-cells = <1>;
-			system1@0 {
-				label = "spi3-system1";
-				reg = <0x0 0x800000>;
-			};
-			system2@800000 {
-				label = "spi3-system2";
-				reg = <0x800000 0x0>;
+			bios@0 {
+				label = "bios";
+				reg = <0x0 0x2000000>;
 			};
 		};
 	};
@@ -205,84 +235,90 @@
 	status = "okay";
 };
 
+&emc0 {
+	phy-mode = "rmii";
+	use-ncsi;
+	status = "okay";
+};
+
 &i2c1 {
 	status = "okay";
 
-	i2c-mux@70 {
+	i2c-switch@70 {
 		compatible = "nxp,pca9548";
 		#address-cells = <1>;
 		#size-cells = <0>;
 		reg = <0x70>;
 		i2c-mux-idle-disconnect;
 
-		i2c_slot1a: i2c@0 {
+		i2c_slot1a: i2c-bus@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0>;
 		};
 
-		i2c_slot1b: i2c@1 {
+		i2c_slot1b: i2c-bus@1 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <1>;
 		};
 
-		i2c_slot2a: i2c@2 {
+		i2c_slot2a: i2c-bus@2 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <2>;
 		};
 
-		i2c_slot2b: i2c@3 {
+		i2c_slot2b: i2c-bus@3 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <3>;
 		};
 
-		i2c_slot3: i2c@4 {
+		i2c_slot3: i2c-bus@4 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <4>;
 		};
 
-		i2c_slot4: i2c@5 {
+		i2c_slot4: i2c-bus@5 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <5>;
 		};
 
-		i2c_slot5: i2c@6 {
+		i2c_slot5: i2c-bus@6 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <6>;
 		};
 	};
 
-	i2c-mux@71 {
+	i2c-switch@71 {
 		compatible = "nxp,pca9546";
 		reg = <0x71>;
 		#address-cells = <1>;
 		#size-cells = <0>;
 		i2c-mux-idle-disconnect;
 
-		i2c_m2_s1: i2c@0 {
+		i2c_m2_s1: i2c-bus@0 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <0>;
 		};
 
-		i2c_m2_s2: i2c@1 {
+		i2c_m2_s2: i2c-bus@1 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <1>;
 		};
-		i2c_m2_s3: i2c@2 {
+		i2c_m2_s3: i2c-bus@2 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <2>;
 		};
 
-		i2c_m2_s4: i2c@3 {
+		i2c_m2_s4: i2c-bus@3 {
 			#address-cells = <1>;
 			#size-cells = <0>;
 			reg = <3>;
@@ -299,7 +335,7 @@
 	};
 
 	power-supply@58 {
-		compatible = "delta,dps800";
+		compatible = "flexpower";
 		reg = <0x58>;
 	};
 };
@@ -320,9 +356,14 @@
 &i2c5 {
 	status = "okay";
 
-	i2c-slave-mqueue@10 {
+	ipmb@40000010 {
+		compatible = "ipmb-dev";
+		reg = <0x40000010>;
+		i2c-protocol;
+	};
+
+	slave_mqueue: i2c-slave-mqueue {
 		compatible = "i2c-slave-mqueue";
-		reg = <(I2C_OWN_SLAVE_ADDRESS | 0x10)>;
 	};
 };
 
@@ -415,6 +456,8 @@
 
 		gpio-controller;
 		#gpio-cells = <2>;
+		gpio-line-names="","","","","","","","",
+						"","","SIO_POWER_GOOD","","","","","";
 	};
 };
 
@@ -427,91 +470,91 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		reset-gpios = <&gpio7 4 GPIO_ACTIVE_LOW>;
-		g1a-p0-0-hog {
+		G1A_P0_0 {
 			gpio-hog;
 			gpios = <0 0>;
 			output-high;
 			line-name = "TPM_BMC_ALERT_N";
 		};
-		g1a-p0-1-hog {
+		G1A_P0_1 {
 			gpio-hog;
 			gpios = <1 0>;
 			input;
 			line-name = "FM_BIOS_TOP_SWAP";
 		};
-		g1a-p0-2-hog {
+		G1A_P0_2 {
 			gpio-hog;
 			gpios = <2 0>;
 			input;
 			line-name = "FM_BIOS_PREFRB2_GOOD";
 		};
-		g1a-p0-3-hog {
+		G1A_P0_3 {
 			gpio-hog;
 			gpios = <3 0>;
 			input;
 			line-name = "BMC_SATAXPCIE_0TO3_SEL";
 		};
-		g1a-p0-4-hog {
+		G1A_P0_4 {
 			gpio-hog;
 			gpios = <4 0>;
 			input;
 			line-name = "BMC_SATAXPCIE_4TO7_SEL";
 		};
-		g1a-p0-5-hog {
+		G1A_P0_5 {
 			gpio-hog;
 			gpios = <5 0>;
 			output-low;
 			line-name = "FM_UV_ADR_TRIGGER_EN_N";
 		};
-		g1a-p0-6-hog {
+		G1A_P0_6 {
 			gpio-hog;
 			gpios = <6 0>;
 			input;
 			line-name = "RM_THROTTLE_EN_N";
 		};
-		g1a-p1-0-hog {
+		G1A_P1_0 {
 			gpio-hog;
 			gpios = <8 0>;
 			input;
 			line-name = "FM_BMC_TPM_PRES_N";
 		};
-		g1a-p1-1-hog {
+		G1A_P1_1 {
 			gpio-hog;
 			gpios = <9 0>;
 			input;
 			line-name = "FM_CPU0_SKTOCC_LVT3_N";
 		};
-		g1a-p1-2-hog {
+		G1A_P1_2 {
 			gpio-hog;
 			gpios = <10 0>;
 			input;
 			line-name = "FM_CPU1_SKTOCC_LVT3_N";
 		};
-		g1a-p1-3-hog {
+		G1A_P1_3 {
 			gpio-hog;
 			gpios = <11 0>;
 			input;
 			line-name = "PSU1_ALERT_N";
 		};
-		g1a-p1-4-hog {
+		G1A_P1_4 {
 			gpio-hog;
 			gpios = <12 0>;
 			input;
 			line-name = "PSU2_ALERT_N";
 		};
-		g1a-p1-5-hog {
+		G1A_P1_5 {
 			gpio-hog;
 			gpios = <13 0>;
 			input;
 			line-name = "H_CPU0_FAST_WAKE_LVT3_N";
 		};
-		g1a-p1-6-hog {
+		G1A_P1_6 {
 			gpio-hog;
 			gpios = <14 0>;
 			output-high;
 			line-name = "I2C_MUX1_RESET_N";
 		};
-		g1a-p1-7-hog {
+		G1A_P1_7 {
 			gpio-hog;
 			gpios = <15 0>;
 			input;
@@ -524,91 +567,91 @@
 		reg = <0x75>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		g1b-p0-0-hog {
+		G1B_P0_0 {
 			gpio-hog;
 			gpios = <0 0>;
 			input;
 			line-name = "PVDDQ_ABC_PINALERT_N";
 		};
-		g1b-p0-1-hog {
+		G1B_P0_1 {
 			gpio-hog;
 			gpios = <1 0>;
 			input;
 			line-name = "PVDDQ_DEF_PINALERT_N";
 		};
-		g1b-p0-2-hog {
+		G1B_P0_2 {
 			gpio-hog;
 			gpios = <2 0>;
 			input;
 			line-name = "PVDDQ_GHJ_PINALERT_N";
 		};
-		g1b-p0-3-hog {
+		G1B_P0_3 {
 			gpio-hog;
 			gpios = <3 0>;
 			input;
 			line-name = "PVDDQ_KLM_PINALERT_N";
 		};
-		g1b-p0-5-hog {
+		G1B_P0_5 {
 			gpio-hog;
 			gpios = <5 0>;
 			input;
 			line-name = "FM_BOARD_REV_ID0";
 		};
-		g1b-p0-6-hog {
+		G1B_P0_6 {
 			gpio-hog;
 			gpios = <6 0>;
 			input;
 			line-name = "FM_BOARD_REV_ID1";
 		};
-		g1b-p0-7-hog {
+		G1B_P0_7 {
 			gpio-hog;
 			gpios = <7 0>;
 			input;
 			line-name = "FM_BOARD_REV_ID2";
 		};
-		g1b-p1-0-hog {
+		G1B_P1_0 {
 			gpio-hog;
 			gpios = <8 0>;
 			input;
 			line-name = "FM_OC_DETECT_EN_N";
 		};
-		g1b-p1-1-hog {
+		G1B_P1_1 {
 			gpio-hog;
 			gpios = <9 0>;
 			input;
 			line-name = "FM_FLASH_DESC_OVERRIDE";
 		};
-		g1b-p1-2-hog {
+		G1B_P1_2 {
 			gpio-hog;
 			gpios = <10 0>;
 			output-low;
 			line-name = "FP_PWR_ID_LED_N";
 		};
-		g1b-p1-3-hog {
+		G1B_P1_3 {
 			gpio-hog;
 			gpios = <11 0>;
 			output-low;
 			line-name = "BMC_LED_PWR_GRN";
 		};
-		g1b-p1-4-hog {
+		G1B_P1_4 {
 			gpio-hog;
 			gpios = <12 0>;
 			output-low;
 			line-name = "BMC_LED_PWR_AMBER";
 		};
-		g1b-p1-5-hog {
+		G1B_P1_5 {
 			gpio-hog;
 			gpios = <13 0>;
 			output-high;
 			line-name = "FM_BMC_FAULT_LED_N";
 		};
-		g1b-p1-6-hog {
+		G1B_P1_6 {
 			gpio-hog;
 			gpios = <14 0>;
 			output-high;
 			line-name = "FM_CPLD_BMC_PWRDN_N";
 		};
-		g1b-p1-7-hog {
+		G1B_P1_7 {
 			gpio-hog;
 			gpios = <15 0>;
 			output-high;
@@ -626,96 +669,84 @@
 		gpio-controller;
 		#gpio-cells = <2>;
 		reset-gpios = <&gpio5 28 GPIO_ACTIVE_LOW>;
-		g2a-p0-0-hog {
+		interrupt-parent = <&gpio5>;
+		interrupts = <29 IRQ_TYPE_LEVEL_LOW>;
+		gpio-line-names="","","","POWER_OUT","RESET_OUT","","","",
+						"","","","","","","POST_COMPLETE","";
+		G2A_P0_0 {
 			gpio-hog;
 			gpios = <0 0>;
 			output-high;
 			line-name = "BMC_PON_RST_REQ_N";
 		};
-		g2a-p0-1-hog {
+		G2A_P0_1 {
 			gpio-hog;
 			gpios = <1 0>;
 			output-high;
 			line-name = "BMC_RST_IND_REQ_N";
 		};
-		g2a-p0-2-hog {
+		G2A_P0_2 {
 			gpio-hog;
 			gpios = <2 0>;
 			input;
 			line-name = "RST_BMC_RTCRST";
 		};
-		g2a-p0-3-hog {
-			gpio-hog;
-			gpios = <3 0>;
-			output-high;
-			line-name = "FM_BMC_PWRBTN_OUT_N";
-		};
-		g2a-p0-4-hog {
-			gpio-hog;
-			gpios = <4 0>;
-			output-high;
-			line-name = "RST_BMC_SYSRST_BTN_OUT_N";
-		};
-		g2a-p0-5-hog {
+
+		G2A_P0_5 {
 			gpio-hog;
 			gpios = <5 0>;
 			output-high;
 			line-name = "FM_BATTERY_SENSE_EN_N";
 		};
-		g2a-p0-6-hog {
+		G2A_P0_6 {
 			gpio-hog;
 			gpios = <6 0>;
 			output-high;
 			line-name = "FM_BMC_READY_N";
 		};
-		g2a-p0-7-hog {
+		G2A_P0_7 {
 			gpio-hog;
 			gpios = <7 0>;
 			input;
 			line-name = "IRQ_BMC_PCH_SMI_LPC_N";
 		};
-		g2a-p1-0-hog {
+		G2A_P1_0 {
 			gpio-hog;
 			gpios = <8 0>;
 			input;
 			line-name = "FM_SLOT4_CFG0";
 		};
-		g2a-p1-1-hog {
+		G2A_P1_1 {
 			gpio-hog;
 			gpios = <9 0>;
 			input;
 			line-name = "FM_SLOT4_CFG1";
 		};
-		g2a-p1-2-hog {
+		G2A_P1_2 {
 			gpio-hog;
 			gpios = <10 0>;
 			input;
 			line-name = "FM_NVDIMM_EVENT_N";
 		};
-		g2a-p1-3-hog {
+		G2A_P1_3 {
 			gpio-hog;
 			gpios = <11 0>;
 			input;
 			line-name = "PSU1_BLADE_EN_N";
 		};
-		g2a-p1-4-hog {
+		G2A_P1_4 {
 			gpio-hog;
 			gpios = <12 0>;
 			input;
 			line-name = "BMC_PCH_FNM";
 		};
-		g2a-p1-5-hog {
+		G2A_P1_5 {
 			gpio-hog;
 			gpios = <13 0>;
 			input;
 			line-name = "FM_SOL_UART_CH_SEL";
 		};
-		g2a-p1-6-hog {
-			gpio-hog;
-			gpios = <14 0>;
-			input;
-			line-name = "FM_BIOS_POST_CMPLT_N";
-		};
+
 	};
 
 	pca9539_g2b: pca9539-g2b@75 {
@@ -723,91 +754,97 @@
 		reg = <0x75>;
 		gpio-controller;
 		#gpio-cells = <2>;
-		g2b-p0-0-hog {
+		interrupt-parent = <&gpio5>;
+		interrupts = <29 IRQ_TYPE_LEVEL_LOW>;
+		#interrupt-cells = <2>;
+		interrupt-controller;
+		gpio-line-names="","","","","","","","",
+						"","","","","","","","";
+		G2B_P0_0 {
 			gpio-hog;
 			gpios = <0 0>;
 			input;
 			line-name = "FM_CPU_MSMI_LVT3_N";
 		};
-		g2b-p0-1-hog {
+		G2B_P0_1 {
 			gpio-hog;
 			gpios = <1 0>;
 			input;
 			line-name = "FM_BIOS_MRC_DEBUG_MSG_DIS";
 		};
-		g2b-p0-2-hog {
+		G2B_P0_2 {
 			gpio-hog;
 			gpios = <2 0>;
 			input;
 			line-name = "FM_CPU1_DISABLE_BMC_N";
 		};
-		g2b-p0-3-hog {
+		G2B_P0_3 {
 			gpio-hog;
 			gpios = <3 0>;
 			output-low;
 			line-name = "BMC_JTAG_SELECT";
 		};
-		g2b-p0-4-hog {
+		G2B_P0_4 {
 			gpio-hog;
 			gpios = <4 0>;
 			output-high;
 			line-name = "PECI_MUX_SELECT";
 		};
-		g2b-p0-5-hog {
+		G2B_P0_5 {
 			gpio-hog;
 			gpios = <5 0>;
 			output-high;
 			line-name = "I2C_MUX2_RESET_N";
 		};
-		g2b-p0-6-hog {
+		G2B_P0_6 {
 			gpio-hog;
 			gpios = <6 0>;
 			input;
 			line-name = "FM_BMC_CPLD_PSU2_ON";
 		};
-		g2b-p0-7-hog {
+		G2B_P0_7 {
 			gpio-hog;
 			gpios = <7 0>;
 			output-high;
 			line-name = "PSU2_ALERT_EN_N";
 		};
-		g2b-p1-0-hog {
+		G2B_P1_0 {
 			gpio-hog;
 			gpios = <8 0>;
 			output-high;
 			line-name = "FM_CPU_BMC_INIT";
 		};
-		g2b-p1-1-hog {
+		G2B_P1_1 {
 			gpio-hog;
 			gpios = <9 0>;
 			output-high;
 			line-name = "IRQ_BMC_PCH_SCI_LPC_N";
 		};
-		g2b-p1-2-hog {
+		G2B_P1_2 {
 			gpio-hog;
 			gpios = <10 0>;
 			output-low;
 			line-name = "PMB_ALERT_EN_N";
 		};
-		g2b-p1-3-hog {
+		G2B_P1_3 {
 			gpio-hog;
 			gpios = <11 0>;
 			output-high;
 			line-name = "FM_FAST_PROCHOT_EN_N";
 		};
-		g2b-p1-4-hog {
+		G2B_P1_4 {
 			gpio-hog;
 			gpios = <12 0>;
 			output-high;
 			line-name = "BMC_NVDIMM_PRSNT_N";
 		};
-		g2b-p1-5-hog {
+		G2B_P1_5 {
 			gpio-hog;
 			gpios = <13 0>;
 			output-low;
 			line-name = "FM_BACKUP_BIOS_SEL_H_BMC";
 		};
-		g2b-p1-6-hog {
+		G2B_P1_6 {
 			gpio-hog;
 			gpios = <14 0>;
 			output-high;
@@ -824,7 +861,7 @@
 		reg = <0x4a>;
 		status = "okay";
 	};
-	eeprom@51 {
+	m24128_fru@51 {
 		compatible = "atmel,24c128";
 		reg = <0x51>;
 		pagesize = <64>;
@@ -885,11 +922,89 @@
 	};
 };
 
+&peci0 {
+	cmd-timeout-ms = <1000>;
+	npcm,pull-down = <0>;
+	npcm,host-neg-bit-rate = <15>;
+	status = "okay";
+
+	intel-peci-dimmtemp@30 {
+		compatible = "intel,peci-client";
+		reg = <0x30>;
+	};
+	intel-peci-dimmtemp@31 {
+		compatible = "intel,peci-client";
+		reg = <0x31>;
+	};
+};
+
 &ehci1 {
 	status = "okay";
 };
 
+&ohci1 {
+	status = "okay";
+};
+
+&udc0 {
+	status = "okay";
+};
+
+&udc1 {
+	status = "okay";
+};
+
+&udc2 {
+	status = "okay";
+};
+
+&udc3 {
+	status = "okay";
+};
+
+&udc4 {
+	status = "okay";
+};
+
+&udc5 {
+	status = "okay";
+};
+
+&udc6 {
+	status = "okay";
+};
+
+&udc7 {
+	status = "okay";
+};
+
+&udc8 {
+	status = "okay";
+};
+
+&udc9 {
+	status = "okay";
+};
+
+&aes {
+	status = "okay";
+};
+
+&sha {
+	status = "okay";
+};
+
+
+&sdhci0 {
+	status = "okay";
+};
+
+&pcimbox {
+	status = "okay";
+};
+
 &watchdog1 {
+	nuvoton,ext1-reset-type = "wd1";
 	status = "okay";
 };
 
@@ -918,6 +1033,10 @@
 	status = "okay";
 };
 
+&otp {
+	status = "okay";
+};
+
 &kcs1 {
 	status = "okay";
 };
@@ -930,12 +1049,44 @@
 	status = "okay";
 };
 
+&lpc_bpc {
+	monitor-ports = <0x80>;
+	status = "okay";
+};
+
 &spi0 {
 	cs-gpios = <&gpio6 11 GPIO_ACTIVE_LOW>;
 	status = "okay";
 };
 
 &spi1 {
+	/delete-property/ pinctrl-names;
+	/delete-property/ pinctrl-0;
+	cs-gpios = <&gpio6 0 GPIO_ACTIVE_HIGH>;
+	status = "okay";
+	jtag_master {
+		compatible = "nuvoton,npcm750-jtag-master";
+		spi-max-frequency = <25000000>;
+		reg = <0>;
+
+		pinctrl-names = "pspi", "gpio";
+		pinctrl-0 = <&pspi2_pins>;
+		pinctrl-1 = <&gpio17_pins &gpio18o_pins
+				&gpio19ol_pins>;
+
+		tck-gpios = <&gpio0 19 GPIO_ACTIVE_HIGH>;
+		tdi-gpios = <&gpio0 18 GPIO_ACTIVE_HIGH>;
+		tdo-gpios = <&gpio0 17 GPIO_ACTIVE_HIGH>;
+		tms-gpios = <&gpio0 16 GPIO_ACTIVE_HIGH>;
+		status = "okay";
+	};
+};
+
+&vcd {
+	status = "okay";
+};
+
+&ece {
 	status = "okay";
 };
 
@@ -1049,4 +1200,65 @@
 			&wdog1_pins
 			&wdog2_pins
 			>;
+		gpio0: gpio@f0010000 {
+			/* TCK_MUX_SEL=gpio22 */
+			gpio-line-names =
+			/*0-31*/
+			"","","","","","","","",
+			"","","","","","","","",
+			"","","","","","","TCK_MUX_SEL","",
+			"","","","","","","","";
+		};
+		gpio1: gpio@f0011000 {
+			/* XDP_PRST_N=gpio59 */
+			gpio-line-names =
+			/*32-63*/
+			"","","","","","","","",
+			"","","","","","","","",
+			"","","","","","","","",
+			"","","","XDP_PRST_N","","","","";
+		};
+		gpio2: gpio@f0012000 {
+			/* PREQ_N=gpio78, PRDY_N=gpio79, PLTRST_N=gpio95 */
+			gpio-line-names =
+			/*64-95*/
+			"","","","","","","","",
+			"","","","","","","PREQ_N","PRDY_N",
+			"","","","POWER_BUTTON","","","","",
+			"","","","","","","","PLTRST_N";
+		};
+		gpio4: gpio@f0014000 {
+			/* PWR_DEBUG_N=gpio153, RSMRST_N=gpio155 */
+			gpio-line-names =
+			/*128-159*/
+			"","","","","","","","",
+			"","PS_PWROK","","","","","","",
+			"","RESET_BUTTON","","","","","","",
+			"","PWR_DEBUG_N","","RSMRST_N","","","","";
+		};
+		gpio5: gpio@f0015000 {
+			interrupt-controller;
+			#interrupt-cells = <2>;
+			gpio-line-names =
+				"","","","","","","","",
+				"","","","","","","","",
+				"","","","","","","","",
+				"","","","","","","","";
+		};
+		gpio7: gpio@f0017000 {
+			/* SYSPWROK=gpio229, DEBUG_EN_N=gpio231 */
+			gpio-line-names =
+				/*224-255*/
+				"","","","","","SYSPWROK","","DEBUG_EN_N",
+				"","","","","","","","",
+				"","","","","","","","",
+				"","","","","","","","";
+		};
+};
+
+&lpc_host {
+	lpc_bpc: lpc_bpc@40 {
+		nuvoton,monitor-ports = <0x80>;
+		status = "okay";
+	};
 };

--- a/arch/arm/boot/dts/nuvoton/nuvoton-npcm750.dtsi
+++ b/arch/arm/boot/dts/nuvoton/nuvoton-npcm750.dtsi
@@ -139,5 +139,75 @@
 			dr_mode = "peripheral";
 			status = "disabled";
 		};
+
+		udc5: usb@f0835000 {
+			compatible = "nuvoton,npcm750-udc";
+			reg = <0xf0835000 0x1000
+			       0xfffd2800 0x800>;
+			interrupts = <GIC_SPI 56 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&clk NPCM7XX_CLK_SU>;
+			clock-names = "clk_usb_bridge";
+			phys = <&udc0_phy>;
+			phy_type = "utmi_wide";
+			dr_mode = "peripheral";
+			status = "disabled";
+		};
+
+		udc6: usb@f0836000 {
+			compatible = "nuvoton,npcm750-udc";
+			reg = <0xf0836000 0x1000
+			       0xfffd3000 0x800>;
+			interrupts = <GIC_SPI 57 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&clk NPCM7XX_CLK_SU>;
+			clock-names = "clk_usb_bridge";
+			phys = <&udc0_phy>;
+			phy_type = "utmi_wide";
+			dr_mode = "peripheral";
+			status = "disabled";
+		};
+
+		udc7: usb@f0837000 {
+			compatible = "nuvoton,npcm750-udc";
+			reg = <0xf0837000 0x1000
+			       0xfffd3800 0x800>;
+			interrupts = <GIC_SPI 58 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&clk NPCM7XX_CLK_SU>;
+			clock-names = "clk_usb_bridge";
+			phys = <&udc0_phy>;
+			phy_type = "utmi_wide";
+			dr_mode = "peripheral";
+			status = "disabled";
+		};
+
+		udc8: usb@f0838000 {
+			compatible = "nuvoton,npcm750-udc";
+			reg = <0xf0838000 0x1000
+			       0xfffd4000 0x800>;
+			interrupts = <GIC_SPI 59 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&clk NPCM7XX_CLK_SU>;
+			clock-names = "clk_usb_bridge";
+			phys = <&udc0_phy>;
+			phy_type = "utmi_wide";
+			dr_mode = "peripheral";
+			status = "disabled";
+		};
+
+		udc9: usb@f0839000 {
+			compatible = "nuvoton,npcm750-udc";
+			reg = <0xf0839000 0x1000
+			       0xfffd4800 0x800>;
+			interrupts = <GIC_SPI 60 IRQ_TYPE_LEVEL_HIGH>;
+			clocks = <&clk NPCM7XX_CLK_SU>;
+			clock-names = "clk_usb_bridge";
+			phys = <&udc0_phy>;
+			phy_type = "utmi_wide";
+			dr_mode = "peripheral";
+			status = "disabled";
+		};
+
+		udc0_phy: usb-phy {
+			compatible = "usb-nop-xceiv";
+			#phy-cells = <0>;
+		};
 	};
 };


### PR DESCRIPTION
Restore Olympus DTS content to the 6.1-based layout for NPCM750, including board aliases, flash partition mapping, and platform nodes expected by the existing Olympus userspace stack.

On top of the 6.1 base, keep the extra changes required for current 6.12 behavior:
- add i2c5 slave_mqueue node for userspace queue handling
- add lpc_host/lpc_bpc override with nuvoton,monitor-ports = <0x80> and enable status for POST code capture
- switch lpc_bpc compatible in common NPCM7xx dtsi from "nuvoton,npcm750-lpc-bpc" to "nuvoton,npcm-bpc" so the 6.12 npcm-bpc driver can bind and create /dev/npcm-bpc0

These additions preserve the 6.1 functional baseline while matching 6.12 driver binding requirements for BPC POST code logging.