### PR TITLE
arm64: dts: npcm845: correct TIP RNG register size

### DIFF
--- a/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
+++ b/arch/arm64/boot/dts/nuvoton/nuvoton-common-npcm8xx.dtsi
@@ -304,7 +304,7 @@
 
 		rng_tip: rng_tip@0 {
 			compatible = "nuvoton,npcm845-rng-tip";
-			reg = <0x0 0xf0800E54 0x0 0x10>;
+			reg = <0x0 0xf0800E54 0x0 0x0c>;
 			status = "disabled";
 		};
 


### PR DESCRIPTION
## Summary

The TIP RNG driver accesses three 32-bit registers at offsets 0, 4, and 8 from `0xF0800E54`, but its DT resource currently includes a fourth scratchpad.

Reduce the resource size from `0x10` to `0x0c`, leaving scratchpad 24 at `0xF0800E60` available to its actual owner.

## Motivation

Without this correction, TIP RNG and the Composite EAT client describe overlapping MMIO resources and one probe fails with `-EBUSY`. This is an independent DTS ownership correction and does not enable Composite EAT.

## Validation

- `scripts/checkpatch.pl --strict`: 0 errors, warnings, or checks
- `git diff --check`: pass
- `nuvoton-npcm845-evb.dtb` compile under `W=1`: pass

The emitted NPCM845 unit-address warnings are pre-existing and unrelated to the changed resource size.