### PR TITLE
soc: nuvoton: add Composite EAT mailbox client

### DIFF
--- a/Documentation/devicetree/bindings/soc/nuvoton/nuvoton,npcm845-composite-eat.yaml
+++ b/Documentation/devicetree/bindings/soc/nuvoton/nuvoton,npcm845-composite-eat.yaml
@@ -1,0 +1,82 @@
+# SPDX-License-Identifier: (GPL-2.0-only OR BSD-2-Clause)
+%YAML 1.2
+---
+$id: http://devicetree.org/schemas/soc/nuvoton/nuvoton,npcm845-composite-eat.yaml#
+$schema: http://devicetree.org/meta-schemas/core.yaml#
+
+title: Nuvoton NPCM845 Composite EAT mailbox client
+
+maintainers:
+  - Xiling Sun <xsun@microsoft.com>
+
+description: |
+  The NPCM845 Composite EAT client exchanges a CBOR request and a signed EAT
+  response with TIP firmware through reserved shared memory. Scratchpad
+  registers carry request metadata and mailbox doorbell 4 signals each side.
+
+  ABI version 1 requires a 20-KiB reserved-memory region at physical address
+  0x06201000. The first 4 KiB hold the request and the remaining 16 KiB hold
+  the response.
+
+properties:
+  compatible:
+    const: nuvoton,npcm845-composite-eat
+
+  reg:
+    maxItems: 1
+    description: Scratchpad registers used by the BMC_DIRECT Composite EAT ABI.
+
+  mboxes:
+    maxItems: 1
+    description: NPCM TIP mailbox physical channel 0, doorbell 4.
+
+  mbox-names:
+    const: composite-eat
+
+  memory-region:
+    maxItems: 1
+    description: ABI v1 reserved-memory region at 0x06201000, size 0x5000.
+
+required:
+  - compatible
+  - reg
+  - mboxes
+  - mbox-names
+  - memory-region
+
+additionalProperties: false
+
+examples:
+  - |
+    / {
+        compatible = "nuvoton,npcm845-evb", "nuvoton,npcm845";
+        model = "Nuvoton NPCM845 Composite EAT example";
+        #address-cells = <2>;
+        #size-cells = <2>;
+
+        reserved-memory {
+            #address-cells = <2>;
+            #size-cells = <2>;
+            ranges;
+
+            composite_eat_shm: composite-eat-shm@6201000 {
+                reg = <0x0 0x06201000 0x0 0x00005000>;
+                no-map;
+            };
+        };
+
+
+        tip_mbox: mailbox@f080d000 {
+            compatible = "nuvoton,npcm845-mbox";
+            reg = <0x0 0xf080d000 0x0 0x1000>;
+            #mbox-cells = <2>;
+        };
+
+        composite-eat@f0800e60 {
+            compatible = "nuvoton,npcm845-composite-eat";
+            reg = <0x0 0xf0800e60 0x0 0x20>;
+            mboxes = <&tip_mbox 0 4>;
+            mbox-names = "composite-eat";
+            memory-region = <&composite_eat_shm>;
+        };
+      };

--- a/Documentation/userspace-api/ioctl/ioctl-number.rst
+++ b/Documentation/userspace-api/ioctl/ioctl-number.rst
@@ -382,6 +382,7 @@ Code  Seq#    Include File                                           Comments
 0xDD  00-3F                                                          ZFCP device driver see drivers/s390/scsi/
                                                                      <mailto:aherrman@de.ibm.com>
 0xE5  00-3F  linux/fuse.h
+0xE6  01     uapi/linux/npcm-composite-eat.h                         Nuvoton NPCM Composite EAT
 0xEC  00-01  drivers/platform/chrome/cros_ec_dev.h                   ChromeOS EC driver
 0xEE  00-09  uapi/linux/pfrut.h                                      Platform Firmware Runtime Update and Telemetry
 0xF3  00-3F  drivers/usb/misc/sisusbvga/sisusb.h                     sisfb (in development)

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2757,6 +2757,7 @@ F:	drivers/*/*npcm*
 F:	drivers/rtc/rtc-nct3018y.c
 F:	include/dt-bindings/clock/nuvoton,npcm7xx-clock.h
 F:	include/dt-bindings/clock/nuvoton,npcm845-clk.h
+F:	include/uapi/linux/npcm-composite-eat.h
 
 ARM/NUVOTON NPCM VIDEO ENGINE DRIVER
 M:	Joseph Liu <kwliu@nuvoton.com>

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2755,6 +2755,7 @@ F:	arch/arm64/boot/dts/nuvoton/
 F:	drivers/*/*/*npcm*
 F:	drivers/*/*npcm*
 F:	drivers/soc/nuvoton/npcm-composite-eat-internal.h
+F:	drivers/soc/nuvoton/npcm-composite-eat-test.c
 F:	drivers/soc/nuvoton/npcm-composite-eat.c
 F:	drivers/rtc/rtc-nct3018y.c
 F:	include/dt-bindings/clock/nuvoton,npcm7xx-clock.h

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2747,6 +2747,7 @@ L:	openbmc@lists.ozlabs.org (moderated for non-subscribers)
 S:	Supported
 F:	Documentation/devicetree/bindings/*/*/*npcm*
 F:	Documentation/devicetree/bindings/*/*npcm*
+F:	Documentation/devicetree/bindings/soc/nuvoton/nuvoton,npcm845-composite-eat.yaml
 F:	Documentation/devicetree/bindings/rtc/nuvoton,nct3018y.yaml
 F:	arch/arm/boot/dts/nuvoton/nuvoton-npcm*
 F:	arch/arm/mach-npcm/

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -2754,6 +2754,8 @@ F:	arch/arm/mach-npcm/
 F:	arch/arm64/boot/dts/nuvoton/
 F:	drivers/*/*/*npcm*
 F:	drivers/*/*npcm*
+F:	drivers/soc/nuvoton/npcm-composite-eat-internal.h
+F:	drivers/soc/nuvoton/npcm-composite-eat.c
 F:	drivers/rtc/rtc-nct3018y.c
 F:	include/dt-bindings/clock/nuvoton,npcm7xx-clock.h
 F:	include/dt-bindings/clock/nuvoton,npcm845-clk.h

--- a/drivers/mailbox/npcm-mailbox.c
+++ b/drivers/mailbox/npcm-mailbox.c
@@ -21,25 +21,29 @@ struct npcm_mbox_hw {
 	struct device		*dev;
 	void __iomem		*base;
 	struct mbox_controller	*controller;
+	int			irq;
 };
 
 /**
- * NPCM mailbox allocated channel information
- *
+ * struct npcm_mbox_channel - NPCM mailbox channel information
  * @mhw: Pointer to parent mailbox device
+ * @pchan: Physical mailbox channel
  * @doorbell: doorbell number pertaining to this channel
+ * @active: Whether the channel is bound to a client
  */
 struct npcm_mbox_channel {
 	struct npcm_mbox_hw	*mhw;
 	unsigned int		pchan;
 	unsigned int		doorbell;
+	bool			active;
 };
 
 static inline struct mbox_chan *
 npcm_mbox_to_channel(struct mbox_controller *controller, unsigned int doorbell)
 {
 	struct npcm_mbox_channel *chan_info = controller->chans[doorbell].con_priv;
-	if (chan_info && chan_info->doorbell == doorbell)
+	if (chan_info && READ_ONCE(chan_info->active) &&
+	    chan_info->doorbell == doorbell)
 		return &controller->chans[doorbell];
 
 	return NULL;
@@ -75,9 +79,12 @@ static struct mbox_chan *npcm_mbox_irq_to_channel(struct npcm_mbox_hw *mhw)
 		chan = npcm_mbox_to_channel(controller, doorbell);
 		if (chan)
 			break;
-		dev_err(controller->dev,
-			"Channel 0 not registered yet, doorbell: %d\n",
-			doorbell);
+
+		writel_relaxed(BIT(doorbell),
+			       mhw->base + NPCM_CP2BST_REG_OFFSET);
+		dev_warn_ratelimited(controller->dev,
+				     "doorbell %d has no active channel\n",
+				     doorbell);
 	}
 	return chan;
 }
@@ -108,6 +115,9 @@ static int npcm_send_data(struct mbox_chan *chan, void *data)
 
 static int npcm_startup(struct mbox_chan *chan)
 {
+	struct npcm_mbox_channel *chan_info = chan->con_priv;
+
+	WRITE_ONCE(chan_info->active, true);
 	npcm_mbox_clear_irq(chan);
 	return 0;
 }
@@ -115,12 +125,10 @@ static int npcm_startup(struct mbox_chan *chan)
 static void npcm_shutdown(struct mbox_chan *chan)
 {
 	struct npcm_mbox_channel *chan_info = chan->con_priv;
-	struct mbox_controller *controller = chan_info->mhw->controller;
 
-	/* Reset channel */
+	WRITE_ONCE(chan_info->active, false);
 	npcm_mbox_clear_irq(chan);
-	devm_kfree(controller->dev, chan->con_priv);
-	chan->con_priv = NULL;
+	synchronize_irq(chan_info->mhw->irq);
 }
 
 static bool npcm_last_tx_done(struct mbox_chan *chan)
@@ -169,18 +177,20 @@ static struct mbox_chan *npcm_mbox_xlate(struct mbox_controller *controller,
 	}
 
 	chan = &controller->chans[doorbell];
-	chan_info =
-		devm_kzalloc(controller->dev, sizeof(*chan_info), GFP_KERNEL);
-	if (!chan_info)
-		return ERR_PTR(-ENOMEM);
+	chan_info = chan->con_priv;
+	if (!chan_info) {
+		chan_info = devm_kzalloc(controller->dev, sizeof(*chan_info), GFP_KERNEL);
+		if (!chan_info)
+			return ERR_PTR(-ENOMEM);
+		chan->con_priv = chan_info;
+	}
 
 	chan_info->mhw = mhw;
 	chan_info->doorbell = doorbell;
 	chan_info->pchan = pchan;
-	chan->con_priv = chan_info;
 
 	dev_info(controller->dev,
-		 "controller: created channel 0, doorbell: %d\n", doorbell);
+		 "controller: activated channel 0, doorbell: %d\n", doorbell);
 
 	return chan;
 }
@@ -220,7 +230,7 @@ static int npcm_mbox_probe(struct platform_device *pdev)
 	if (!chans)
 		return -ENOMEM;
 
-	mhw->dev	= &pdev->dev; 
+	mhw->dev	= &pdev->dev;
 	mhw->controller	= mbox;
 
 	mbox->dev = mhw->dev;
@@ -241,8 +251,12 @@ static int npcm_mbox_probe(struct platform_device *pdev)
 	/* Clear all IRQs before claiming IRQ handler */
 	writel_relaxed(0xFFFFFFFF, mhw->base + NPCM_CP2BST_REG_OFFSET);
 
-	err = devm_request_threaded_irq(&pdev->dev, platform_get_irq(pdev, 0),
-					NULL, npcm_mbox_rx_handler,
+	mhw->irq = platform_get_irq(pdev, 0);
+	if (mhw->irq < 0)
+		return mhw->irq;
+
+	err = devm_request_threaded_irq(&pdev->dev, mhw->irq, NULL,
+					npcm_mbox_rx_handler,
 					IRQF_ONESHOT, "npcm_mbox", mhw);
 	if (err) {
 		dev_err(&pdev->dev, "Can't claim IRQ handler %d\n", err);

--- a/drivers/soc/nuvoton/Kconfig
+++ b/drivers/soc/nuvoton/Kconfig
@@ -21,6 +21,19 @@ config NPCM_MBOX_CERBERUS
 	  processors on the BMC such as TIP and CP. 
 	  Select Y here if you want to use NPCM mailbox controller.
 
+config NPCM_COMPOSITE_EAT
+	tristate "NPCM Composite EAT mailbox client"
+	depends on ARCH_NPCM || COMPILE_TEST
+	depends on MAILBOX
+	select NPCM_MBOX
+	help
+	  Provides an ioctl-only mailbox client for BMC_DIRECT Composite EAT
+	  generation requests to TIP firmware. The driver copies a userspace
+	  request into reserved shared memory and returns the signed EAT response.
+
+	  Select Y here to expose /dev/npcm-composite-eat for a platform
+	  attestation daemon.
+
 config WPCM450_SOC
 	tristate "Nuvoton WPCM450 SoC driver"
 	default y if ARCH_WPCM450

--- a/drivers/soc/nuvoton/Kconfig
+++ b/drivers/soc/nuvoton/Kconfig
@@ -84,4 +84,12 @@ config NPCM_TIP_RNG
 	help
 	  This enables access to HW RNG device thourgh TIP in NPCM BMC's.
 
+config NPCM_COMPOSITE_EAT_KUNIT_TEST
+	tristate "KUnit tests for NPCM Composite EAT" if !KUNIT_ALL_TESTS
+	depends on KUNIT
+	default KUNIT_ALL_TESTS
+	help
+	  Tests the NPCM Composite EAT userspace ABI, physical resource bounds,
+	  request IDs, timeout quarantine, stale responses, and reset handling.
+
 endmenu

--- a/drivers/soc/nuvoton/Makefile
+++ b/drivers/soc/nuvoton/Makefile
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: GPL-2.0-only
 obj-$(CONFIG_NPCM_BPC)		+= npcm-bpc.o
 obj-$(CONFIG_NPCM_MBOX_CERBERUS) += npcm-cerberus.o
+obj-$(CONFIG_NPCM_COMPOSITE_EAT) += npcm-composite-eat.o
 obj-$(CONFIG_WPCM450_SOC)	+= wpcm450-soc.o
 obj-$(CONFIG_NPCM_ESPI_MMBI) += npcm-espi-mmbi.o
 obj-$(CONFIG_MTD_NPCM_TIP_FIU)	+= npcm_fiu_tip.o

--- a/drivers/soc/nuvoton/Makefile
+++ b/drivers/soc/nuvoton/Makefile
@@ -2,6 +2,7 @@
 obj-$(CONFIG_NPCM_BPC)		+= npcm-bpc.o
 obj-$(CONFIG_NPCM_MBOX_CERBERUS) += npcm-cerberus.o
 obj-$(CONFIG_NPCM_COMPOSITE_EAT) += npcm-composite-eat.o
+obj-$(CONFIG_NPCM_COMPOSITE_EAT_KUNIT_TEST) += npcm-composite-eat-test.o
 obj-$(CONFIG_WPCM450_SOC)	+= wpcm450-soc.o
 obj-$(CONFIG_NPCM_ESPI_MMBI) += npcm-espi-mmbi.o
 obj-$(CONFIG_MTD_NPCM_TIP_FIU)	+= npcm_fiu_tip.o

--- a/drivers/soc/nuvoton/npcm-composite-eat-internal.h
+++ b/drivers/soc/nuvoton/npcm-composite-eat-internal.h
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: GPL-2.0 */
+#ifndef NPCM_COMPOSITE_EAT_INTERNAL_H
+#define NPCM_COMPOSITE_EAT_INTERNAL_H
+
+#include <linux/errno.h>
+#include <linux/types.h>
+#include <uapi/linux/npcm-composite-eat.h>
+
+#define BMC_DIRECT_COMPOSITE_EAT_SHM_BASE 0x06201000ULL
+#define BMC_DIRECT_COMPOSITE_EAT_REQ_SIZE 0x1000
+#define BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE 0x4000
+#define BMC_DIRECT_COMPOSITE_EAT_SHM_SIZE \
+	(BMC_DIRECT_COMPOSITE_EAT_REQ_SIZE + BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE)
+
+enum npcm_composite_eat_state {
+	NPCM_COMPOSITE_EAT_IDLE,
+	NPCM_COMPOSITE_EAT_IN_FLIGHT,
+	NPCM_COMPOSITE_EAT_QUARANTINED,
+};
+
+struct npcm_composite_eat_request_state {
+	enum npcm_composite_eat_state state;
+	u32 next_request_id;
+	u32 active_request_id;
+};
+
+static inline bool
+npcm_composite_eat_io_valid(const struct npcm_composite_eat_io *io)
+{
+	return io->abi_version == NPCM_COMPOSITE_EAT_ABI_VERSION &&
+		!io->reserved && !io->reserved_req && !io->reserved_resp &&
+		io->req_ptr && io->resp_ptr && io->req_len && io->resp_cap &&
+		io->req_len <= BMC_DIRECT_COMPOSITE_EAT_REQ_SIZE &&
+		io->resp_cap <= BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE;
+}
+
+static inline bool npcm_composite_eat_resource_valid(u64 start, u64 size)
+{
+	return start == BMC_DIRECT_COMPOSITE_EAT_SHM_BASE &&
+		size == BMC_DIRECT_COMPOSITE_EAT_SHM_SIZE &&
+		start + size - 1 <= U32_MAX;
+}
+
+static inline int
+npcm_composite_eat_response_valid(u32 status, u32 resp_len, u32 resp_cap)
+{
+	if (status > NPCM_COMPOSITE_EAT_STATUS_UNSUPPORTED)
+		return -EPROTO;
+
+	if (status == NPCM_COMPOSITE_EAT_STATUS_RESPONSE_TOO_SMALL)
+		return resp_len > resp_cap ? 0 : -EPROTO;
+
+	if (status != NPCM_COMPOSITE_EAT_STATUS_OK)
+		return resp_len ? -EPROTO : 0;
+
+	if (!resp_len)
+		return -EPROTO;
+
+	if (resp_len > resp_cap || resp_len > BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE)
+		return -EMSGSIZE;
+
+	return 0;
+}
+
+static inline bool npcm_composite_eat_tx_requires_quarantine(int ret)
+{
+	return ret == -ETIME;
+}
+
+static inline int
+npcm_composite_eat_state_begin(struct npcm_composite_eat_request_state *state,
+			       u32 *request_id)
+{
+	if (state->state != NPCM_COMPOSITE_EAT_IDLE)
+		return -EBUSY;
+
+	state->state = NPCM_COMPOSITE_EAT_IN_FLIGHT;
+	state->next_request_id++;
+	if (!state->next_request_id)
+		state->next_request_id++;
+	state->active_request_id = state->next_request_id;
+	*request_id = state->active_request_id;
+	return 0;
+}
+
+static inline void
+npcm_composite_eat_state_reset(struct npcm_composite_eat_request_state *state)
+{
+	state->state = NPCM_COMPOSITE_EAT_IDLE;
+	state->active_request_id = 0;
+}
+
+static inline void
+npcm_composite_eat_state_timeout(struct npcm_composite_eat_request_state *state)
+{
+	if (state->state == NPCM_COMPOSITE_EAT_IN_FLIGHT)
+		state->state = NPCM_COMPOSITE_EAT_QUARANTINED;
+}
+
+static inline bool
+npcm_composite_eat_state_response(struct npcm_composite_eat_request_state *state,
+				  u32 response_id)
+{
+	if (response_id != state->active_request_id)
+		return false;
+
+	if (state->state == NPCM_COMPOSITE_EAT_QUARANTINED)
+		npcm_composite_eat_state_reset(state);
+	else if (state->state != NPCM_COMPOSITE_EAT_IN_FLIGHT)
+		return false;
+
+	return true;
+}
+
+static inline bool
+npcm_composite_eat_state_accept(struct npcm_composite_eat_request_state *state,
+				u32 response_id)
+{
+	if (state->state != NPCM_COMPOSITE_EAT_IN_FLIGHT ||
+	    response_id != state->active_request_id) {
+		state->state = NPCM_COMPOSITE_EAT_QUARANTINED;
+		return false;
+	}
+
+	npcm_composite_eat_state_reset(state);
+	return true;
+}
+
+#endif /* NPCM_COMPOSITE_EAT_INTERNAL_H */

--- a/drivers/soc/nuvoton/npcm-composite-eat-test.c
+++ b/drivers/soc/nuvoton/npcm-composite-eat-test.c
@@ -1,0 +1,185 @@
+// SPDX-License-Identifier: GPL-2.0
+
+#include <kunit/test.h>
+#include <linux/module.h>
+#include <linux/stddef.h>
+
+#include "npcm-composite-eat-internal.h"
+
+static void npcm_composite_eat_io_validation_test(struct kunit *test)
+{
+	struct npcm_composite_eat_io io = {
+		.abi_version = NPCM_COMPOSITE_EAT_ABI_VERSION,
+		.req_ptr = 1,
+		.req_len = 1,
+		.resp_ptr = 1,
+		.resp_cap = 1,
+	};
+
+	KUNIT_EXPECT_TRUE(test, npcm_composite_eat_io_valid(&io));
+	KUNIT_EXPECT_EQ(test, sizeof(io), 48UL);
+	KUNIT_EXPECT_EQ(test, offsetof(struct npcm_composite_eat_io, req_ptr), 8UL);
+	KUNIT_EXPECT_EQ(test, offsetof(struct npcm_composite_eat_io, resp_ptr), 24UL);
+	KUNIT_EXPECT_EQ(test, offsetof(struct npcm_composite_eat_io, status), 40UL);
+	KUNIT_EXPECT_EQ(test, _IOC_TYPE(NPCM_COMPOSITE_EAT_GENERATE), 0xE6U);
+	KUNIT_EXPECT_EQ(test, _IOC_SIZE(NPCM_COMPOSITE_EAT_GENERATE), 48U);
+
+	io.abi_version++;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.abi_version = NPCM_COMPOSITE_EAT_ABI_VERSION;
+	io.reserved = 1;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.reserved = 0;
+	io.reserved_req = 1;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.reserved_req = 0;
+	io.reserved_resp = 1;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.reserved_resp = 0;
+	io.req_ptr = 0;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.req_ptr = 1;
+	io.resp_ptr = 0;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.resp_ptr = 1;
+	io.req_len = 0;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.req_len = BMC_DIRECT_COMPOSITE_EAT_REQ_SIZE + 1;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.req_len = 1;
+	io.resp_cap = 0;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+	io.resp_cap = BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE + 1;
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_io_valid(&io));
+}
+
+static void npcm_composite_eat_resource_validation_test(struct kunit *test)
+{
+	u64 base = BMC_DIRECT_COMPOSITE_EAT_SHM_BASE;
+	u64 size = BMC_DIRECT_COMPOSITE_EAT_SHM_SIZE;
+	bool valid;
+
+	valid = npcm_composite_eat_resource_valid(base, size);
+	KUNIT_EXPECT_TRUE(test, valid);
+	valid = npcm_composite_eat_resource_valid(base + 1, size);
+	KUNIT_EXPECT_FALSE(test, valid);
+	valid = npcm_composite_eat_resource_valid(base, size - 1);
+	KUNIT_EXPECT_FALSE(test, valid);
+	valid = npcm_composite_eat_resource_valid(base, size + 1);
+	KUNIT_EXPECT_FALSE(test, valid);
+}
+
+static void npcm_composite_eat_response_validation_test(struct kunit *test)
+{
+	u32 resp_len;
+	u32 status;
+	int ret;
+
+	status = NPCM_COMPOSITE_EAT_STATUS_OK;
+	ret = npcm_composite_eat_response_valid(status, 1, 1);
+	KUNIT_EXPECT_EQ(test, ret, 0);
+	ret = npcm_composite_eat_response_valid(status, 0, 1);
+	KUNIT_EXPECT_EQ(test, ret, -EPROTO);
+	ret = npcm_composite_eat_response_valid(status, 2, 1);
+	KUNIT_EXPECT_EQ(test, ret, -EMSGSIZE);
+	status = NPCM_COMPOSITE_EAT_STATUS_RESPONSE_TOO_SMALL;
+	ret = npcm_composite_eat_response_valid(status, 2, 1);
+	KUNIT_EXPECT_EQ(test, ret, 0);
+	ret = npcm_composite_eat_response_valid(status, 1, 1);
+	KUNIT_EXPECT_EQ(test, ret, -EPROTO);
+	resp_len = BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE + 1;
+	ret = npcm_composite_eat_response_valid(status, resp_len, 1);
+	KUNIT_EXPECT_EQ(test, ret, 0);
+	status = NPCM_COMPOSITE_EAT_STATUS_BAD_REQUEST;
+	ret = npcm_composite_eat_response_valid(status, 1, 1);
+	KUNIT_EXPECT_EQ(test, ret, -EPROTO);
+	ret = npcm_composite_eat_response_valid(status, 0, 1);
+	KUNIT_EXPECT_EQ(test, ret, 0);
+	status = NPCM_COMPOSITE_EAT_STATUS_UNSUPPORTED + 1;
+	ret = npcm_composite_eat_response_valid(status, 0, 1);
+	KUNIT_EXPECT_EQ(test, ret, -EPROTO);
+}
+
+static void npcm_composite_eat_tx_result_test(struct kunit *test)
+{
+	KUNIT_EXPECT_TRUE(test, npcm_composite_eat_tx_requires_quarantine(-ETIME));
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_tx_requires_quarantine(-ENOBUFS));
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_tx_requires_quarantine(0));
+}
+
+static void npcm_composite_eat_state_test(struct kunit *test)
+{
+	struct npcm_composite_eat_request_state state = {0};
+	u32 request_id;
+
+	KUNIT_ASSERT_EQ(test, npcm_composite_eat_state_begin(&state, &request_id), 0);
+	KUNIT_EXPECT_EQ(test, request_id, 1U);
+	KUNIT_EXPECT_EQ(test, state.state, NPCM_COMPOSITE_EAT_IN_FLIGHT);
+	KUNIT_EXPECT_EQ(test, npcm_composite_eat_state_begin(&state, &request_id),
+			-EBUSY);
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_state_response(&state, 2));
+	KUNIT_EXPECT_TRUE(test, npcm_composite_eat_state_response(&state, 1));
+	KUNIT_EXPECT_TRUE(test, npcm_composite_eat_state_accept(&state, 1));
+	KUNIT_EXPECT_EQ(test, state.state, NPCM_COMPOSITE_EAT_IDLE);
+}
+
+static void npcm_composite_eat_timeout_test(struct kunit *test)
+{
+	struct npcm_composite_eat_request_state state = {0};
+	u32 request_id;
+
+	KUNIT_ASSERT_EQ(test, npcm_composite_eat_state_begin(&state, &request_id), 0);
+	npcm_composite_eat_state_timeout(&state);
+	KUNIT_EXPECT_EQ(test, state.state, NPCM_COMPOSITE_EAT_QUARANTINED);
+	KUNIT_EXPECT_EQ(test, npcm_composite_eat_state_begin(&state, &request_id),
+			-EBUSY);
+	KUNIT_EXPECT_FALSE(test, npcm_composite_eat_state_response(&state, 2));
+	KUNIT_EXPECT_EQ(test, state.state, NPCM_COMPOSITE_EAT_QUARANTINED);
+	KUNIT_EXPECT_TRUE(test, npcm_composite_eat_state_response(&state, 1));
+	KUNIT_EXPECT_EQ(test, state.state, NPCM_COMPOSITE_EAT_IDLE);
+}
+
+static void npcm_composite_eat_request_id_wrap_test(struct kunit *test)
+{
+	struct npcm_composite_eat_request_state state = {
+		.next_request_id = U32_MAX,
+	};
+	u32 request_id;
+
+	KUNIT_ASSERT_EQ(test, npcm_composite_eat_state_begin(&state, &request_id), 0);
+	KUNIT_EXPECT_EQ(test, request_id, 1U);
+}
+
+static void npcm_composite_eat_state_reset_test(struct kunit *test)
+{
+	struct npcm_composite_eat_request_state state = {0};
+	u32 request_id;
+
+	KUNIT_ASSERT_EQ(test, npcm_composite_eat_state_begin(&state, &request_id), 0);
+	npcm_composite_eat_state_timeout(&state);
+	KUNIT_ASSERT_EQ(test, state.state, NPCM_COMPOSITE_EAT_QUARANTINED);
+	npcm_composite_eat_state_reset(&state);
+	KUNIT_EXPECT_EQ(test, state.state, NPCM_COMPOSITE_EAT_IDLE);
+	KUNIT_EXPECT_EQ(test, state.active_request_id, 0U);
+}
+
+static struct kunit_case npcm_composite_eat_test_cases[] = {
+	KUNIT_CASE(npcm_composite_eat_io_validation_test),
+	KUNIT_CASE(npcm_composite_eat_resource_validation_test),
+	KUNIT_CASE(npcm_composite_eat_response_validation_test),
+	KUNIT_CASE(npcm_composite_eat_tx_result_test),
+	KUNIT_CASE(npcm_composite_eat_state_test),
+	KUNIT_CASE(npcm_composite_eat_timeout_test),
+	KUNIT_CASE(npcm_composite_eat_request_id_wrap_test),
+	KUNIT_CASE(npcm_composite_eat_state_reset_test),
+	{}
+};
+
+static struct kunit_suite npcm_composite_eat_test_suite = {
+	.name = "npcm-composite-eat",
+	.test_cases = npcm_composite_eat_test_cases,
+};
+
+kunit_test_suite(npcm_composite_eat_test_suite);
+
+MODULE_LICENSE("GPL");

--- a/drivers/soc/nuvoton/npcm-composite-eat.c
+++ b/drivers/soc/nuvoton/npcm-composite-eat.c
@@ -1,0 +1,456 @@
+// SPDX-License-Identifier: GPL-2.0
+// Copyright (c) 2026, Microsoft Corporation
+
+#include <linux/compat.h>
+#include <linux/completion.h>
+#include <linux/fs.h>
+#include <linux/io.h>
+#include <linux/kref.h>
+#include <linux/mailbox_client.h>
+#include <linux/miscdevice.h>
+#include <linux/module.h>
+#include <linux/mutex.h>
+#include <linux/of_address.h>
+#include <linux/platform_device.h>
+#include <linux/slab.h>
+#include <linux/spinlock.h>
+#include <linux/uaccess.h>
+#include <linux/npcm-composite-eat.h>
+
+#include "npcm-composite-eat-internal.h"
+
+#define NPCM_COMPOSITE_EAT_DEVICE_NAME "npcm-composite-eat"
+#define BMC_DIRECT_COMMAND_COMPOSITE_EAT 0x11
+
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_COMMAND 0x00
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_REQ_ADDR 0x04
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_REQ_LEN 0x08
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESP_ADDR 0x0c
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESP_CAP 0x10
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESP_LEN 0x14
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_REQUEST_ID 0x18
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESPONSE_ID 0x1c
+#define BMC_DIRECT_COMPOSITE_EAT_SCRPAD_SIZE 0x20
+
+#define BMC_DIRECT_COMPOSITE_EAT_REQ_OFFSET 0x0000
+#define BMC_DIRECT_COMPOSITE_EAT_RESP_OFFSET 0x1000
+#define NPCM_COMPOSITE_EAT_TIMEOUT_MS 10000
+
+struct npcm_composite_eat {
+	struct device *dev;
+	void __iomem *regs;
+	void __iomem *shm;
+	resource_size_t shm_phys;
+	struct mbox_client cl;
+	struct mbox_chan *chan;
+	struct completion complete;
+	struct mutex lock; /* Serialize userspace submissions and removal. */
+	spinlock_t state_lock; /* Protect request state in IRQ context. */
+	struct npcm_composite_eat_request_state request_state;
+	struct kref refcount;
+	bool removing;
+	struct miscdevice miscdev;
+};
+
+static struct npcm_composite_eat *npcm_composite_eat_from_file(struct file *fp)
+{
+	return container_of(fp->private_data, struct npcm_composite_eat, miscdev);
+}
+
+static void npcm_composite_eat_release_ref(struct kref *refcount)
+{
+	struct npcm_composite_eat *composite_eat =
+		container_of(refcount, struct npcm_composite_eat, refcount);
+
+	kfree(composite_eat);
+}
+
+static int npcm_composite_eat_open(struct inode *inode, struct file *fp)
+{
+	struct npcm_composite_eat *composite_eat = npcm_composite_eat_from_file(fp);
+	int ret = 0;
+
+	if (!kref_get_unless_zero(&composite_eat->refcount))
+		return -ENODEV;
+
+	mutex_lock(&composite_eat->lock);
+	if (composite_eat->removing)
+		ret = -ENODEV;
+	mutex_unlock(&composite_eat->lock);
+
+	if (ret)
+		kref_put(&composite_eat->refcount, npcm_composite_eat_release_ref);
+
+	return ret;
+}
+
+static int npcm_composite_eat_release_file(struct inode *inode, struct file *fp)
+{
+	struct npcm_composite_eat *composite_eat = npcm_composite_eat_from_file(fp);
+
+	kref_put(&composite_eat->refcount, npcm_composite_eat_release_ref);
+	return 0;
+}
+
+static void npcm_composite_eat_rx_callback(struct mbox_client *cl, void *msg)
+{
+	struct npcm_composite_eat *composite_eat =
+		container_of(cl, struct npcm_composite_eat, cl);
+	unsigned long flags;
+	u32 response_id;
+	bool signal_completion;
+
+	spin_lock_irqsave(&composite_eat->state_lock, flags);
+	response_id = readl(composite_eat->regs +
+			    BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESPONSE_ID);
+	signal_completion = npcm_composite_eat_state_response(&composite_eat->request_state,
+							      response_id);
+	if (signal_completion)
+		complete(&composite_eat->complete);
+	spin_unlock_irqrestore(&composite_eat->state_lock, flags);
+}
+
+static int npcm_composite_eat_begin(struct npcm_composite_eat *composite_eat,
+				    u32 *request_id)
+{
+	unsigned long flags;
+	int ret;
+
+	spin_lock_irqsave(&composite_eat->state_lock, flags);
+	ret = npcm_composite_eat_state_begin(&composite_eat->request_state,
+					     request_id);
+	if (!ret)
+		reinit_completion(&composite_eat->complete);
+	spin_unlock_irqrestore(&composite_eat->state_lock, flags);
+
+	return ret;
+}
+
+static void npcm_composite_eat_reset(struct npcm_composite_eat *composite_eat)
+{
+	unsigned long flags;
+
+	spin_lock_irqsave(&composite_eat->state_lock, flags);
+	npcm_composite_eat_state_reset(&composite_eat->request_state);
+	spin_unlock_irqrestore(&composite_eat->state_lock, flags);
+}
+
+static bool npcm_composite_eat_quarantine(struct npcm_composite_eat *composite_eat)
+{
+	unsigned long flags;
+	bool completed;
+
+	spin_lock_irqsave(&composite_eat->state_lock, flags);
+	completed = try_wait_for_completion(&composite_eat->complete);
+	if (!completed)
+		npcm_composite_eat_state_timeout(&composite_eat->request_state);
+	spin_unlock_irqrestore(&composite_eat->state_lock, flags);
+
+	return completed;
+}
+
+static bool npcm_composite_eat_accept(struct npcm_composite_eat *composite_eat)
+{
+	unsigned long flags;
+	u32 response_id;
+	bool matched;
+
+	spin_lock_irqsave(&composite_eat->state_lock, flags);
+	response_id = readl(composite_eat->regs +
+			    BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESPONSE_ID);
+	matched = npcm_composite_eat_state_accept(&composite_eat->request_state,
+						  response_id);
+	spin_unlock_irqrestore(&composite_eat->state_lock, flags);
+
+	return matched;
+}
+
+static long npcm_composite_eat_submit(struct npcm_composite_eat *composite_eat,
+				      struct npcm_composite_eat_io __user *argp)
+{
+	struct npcm_composite_eat_io io;
+	void __user *req_user;
+	void __user *resp_user;
+	void __iomem *req;
+	void __iomem *resp;
+	resource_size_t req_phys;
+	resource_size_t resp_phys;
+	u8 *req_buf;
+	u8 *resp_buf = NULL;
+	unsigned long timeout;
+	u32 request_id;
+	bool preserve_shared_memory = false;
+	long ret = 0;
+	int mbox_ret;
+
+	if (copy_from_user(&io, argp, sizeof(io)))
+		return -EFAULT;
+	if (!npcm_composite_eat_io_valid(&io))
+		return -EINVAL;
+
+	req_user = u64_to_user_ptr(io.req_ptr);
+	resp_user = u64_to_user_ptr(io.resp_ptr);
+	req_buf = memdup_user(req_user, io.req_len);
+	if (IS_ERR(req_buf))
+		return PTR_ERR(req_buf);
+
+	req = composite_eat->shm + BMC_DIRECT_COMPOSITE_EAT_REQ_OFFSET;
+	resp = composite_eat->shm + BMC_DIRECT_COMPOSITE_EAT_RESP_OFFSET;
+	req_phys = composite_eat->shm_phys + BMC_DIRECT_COMPOSITE_EAT_REQ_OFFSET;
+	resp_phys = composite_eat->shm_phys + BMC_DIRECT_COMPOSITE_EAT_RESP_OFFSET;
+
+	mutex_lock(&composite_eat->lock);
+	if (composite_eat->removing) {
+		ret = -ENODEV;
+		goto out_unlock;
+	}
+	ret = npcm_composite_eat_begin(composite_eat, &request_id);
+	if (ret)
+		goto out_unlock;
+
+	memset_io(req, 0, BMC_DIRECT_COMPOSITE_EAT_REQ_SIZE);
+	memset_io(resp, 0, BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE);
+	memcpy_toio(req, req_buf, io.req_len);
+
+	writel(BMC_DIRECT_COMMAND_COMPOSITE_EAT,
+	       composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_COMMAND);
+	writel(lower_32_bits(req_phys),
+	       composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_REQ_ADDR);
+	writel(io.req_len,
+	       composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_REQ_LEN);
+	writel(lower_32_bits(resp_phys),
+	       composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESP_ADDR);
+	writel(io.resp_cap,
+	       composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESP_CAP);
+	writel(0, composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESP_LEN);
+	writel(request_id,
+	       composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_REQUEST_ID);
+	writel(0,
+	       composite_eat->regs + BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESPONSE_ID);
+
+	mbox_ret = mbox_send_message(composite_eat->chan, composite_eat);
+	if (mbox_ret < 0) {
+		if (npcm_composite_eat_tx_requires_quarantine(mbox_ret)) {
+			if (npcm_composite_eat_quarantine(composite_eat))
+				goto response_ready;
+			dev_warn(composite_eat->dev,
+				 "request %u transmit timed out; waiting for its response or BMC reset\n",
+				 request_id);
+			ret = mbox_ret;
+			preserve_shared_memory = true;
+			goto out_unlock;
+		}
+		ret = mbox_ret;
+		npcm_composite_eat_reset(composite_eat);
+		goto out_clear;
+	}
+
+	timeout = wait_for_completion_timeout(&composite_eat->complete,
+					      msecs_to_jiffies(NPCM_COMPOSITE_EAT_TIMEOUT_MS));
+	if (!timeout && !npcm_composite_eat_quarantine(composite_eat)) {
+		dev_warn(composite_eat->dev,
+			 "request %u timed out; waiting for its response or BMC reset\n",
+			 request_id);
+		ret = -ETIMEDOUT;
+		preserve_shared_memory = true;
+		goto out_unlock;
+	}
+
+response_ready:
+	if (!npcm_composite_eat_accept(composite_eat)) {
+		ret = -EPROTO;
+		preserve_shared_memory = true;
+		goto out_unlock;
+	}
+
+	io.status = readl(composite_eat->regs +
+			  BMC_DIRECT_COMPOSITE_EAT_SCRPAD_COMMAND);
+	io.resp_len = readl(composite_eat->regs +
+			    BMC_DIRECT_COMPOSITE_EAT_SCRPAD_RESP_LEN);
+	ret = npcm_composite_eat_response_valid(io.status, io.resp_len, io.resp_cap);
+	if (ret)
+		goto out_clear;
+
+	if (io.status != NPCM_COMPOSITE_EAT_STATUS_OK) {
+		if (copy_to_user(argp, &io, sizeof(io)))
+			ret = -EFAULT;
+		goto out_clear;
+	}
+
+	resp_buf = kmalloc(io.resp_len, GFP_KERNEL);
+	if (!resp_buf) {
+		ret = -ENOMEM;
+		goto out_clear;
+	}
+	memcpy_fromio(resp_buf, resp, io.resp_len);
+	if (copy_to_user(resp_user, resp_buf, io.resp_len)) {
+		ret = -EFAULT;
+		goto out_clear;
+	}
+	if (copy_to_user(argp, &io, sizeof(io)))
+		ret = -EFAULT;
+
+out_clear:
+	kfree(resp_buf);
+	if (!preserve_shared_memory) {
+		memset_io(req, 0, BMC_DIRECT_COMPOSITE_EAT_REQ_SIZE);
+		memset_io(resp, 0, BMC_DIRECT_COMPOSITE_EAT_RESP_SIZE);
+	}
+out_unlock:
+	mutex_unlock(&composite_eat->lock);
+	kfree(req_buf);
+	return ret;
+}
+
+static long npcm_composite_eat_ioctl(struct file *fp, unsigned int cmd,
+				     unsigned long arg)
+{
+	struct npcm_composite_eat *composite_eat = npcm_composite_eat_from_file(fp);
+
+	if (_IOC_TYPE(cmd) != NPCM_COMPOSITE_EAT_IOCTL_MAGIC)
+		return -ENOTTY;
+
+	switch (cmd) {
+	case NPCM_COMPOSITE_EAT_GENERATE:
+		return npcm_composite_eat_submit(composite_eat,
+			(struct npcm_composite_eat_io __user *)arg);
+	default:
+		return -ENOTTY;
+	}
+}
+
+static const struct file_operations npcm_composite_eat_fops = {
+	.owner = THIS_MODULE,
+	.open = npcm_composite_eat_open,
+	.release = npcm_composite_eat_release_file,
+	.unlocked_ioctl = npcm_composite_eat_ioctl,
+	.compat_ioctl = compat_ptr_ioctl,
+	.llseek = noop_llseek,
+};
+
+static int npcm_composite_eat_probe(struct platform_device *pdev)
+{
+	struct device *dev = &pdev->dev;
+	struct device_node *shmem;
+	struct npcm_composite_eat *composite_eat;
+	struct resource *regs_res;
+	struct resource res;
+	int ret;
+
+	composite_eat = kzalloc(sizeof(*composite_eat), GFP_KERNEL);
+	if (!composite_eat)
+		return -ENOMEM;
+	kref_init(&composite_eat->refcount);
+
+	regs_res = platform_get_resource(pdev, IORESOURCE_MEM, 0);
+	if (!regs_res ||
+	    resource_size(regs_res) < BMC_DIRECT_COMPOSITE_EAT_SCRPAD_SIZE) {
+		ret = dev_err_probe(dev, -EINVAL, "scratchpad resource too small\n");
+		goto err_put;
+	}
+
+	composite_eat->dev = dev;
+	composite_eat->regs = devm_platform_ioremap_resource(pdev, 0);
+	if (IS_ERR(composite_eat->regs)) {
+		ret = PTR_ERR(composite_eat->regs);
+		goto err_put;
+	}
+
+	shmem = of_parse_phandle(dev->of_node, "memory-region", 0);
+	if (!shmem) {
+		ret = dev_err_probe(dev, -ENODEV, "missing memory-region\n");
+		goto err_put;
+	}
+	ret = of_address_to_resource(shmem, 0, &res);
+	of_node_put(shmem);
+	if (ret) {
+		ret = dev_err_probe(dev, ret, "failed to parse memory-region\n");
+		goto err_put;
+	}
+
+	composite_eat->shm_phys = res.start;
+	if (!npcm_composite_eat_resource_valid(res.start, resource_size(&res))) {
+		ret = dev_err_probe(dev, -EINVAL,
+				    "shared memory must be 0x%x bytes at 0x%llx\n",
+				    BMC_DIRECT_COMPOSITE_EAT_SHM_SIZE,
+				    BMC_DIRECT_COMPOSITE_EAT_SHM_BASE);
+		goto err_put;
+	}
+
+	composite_eat->shm = devm_ioremap_resource(dev, &res);
+	if (IS_ERR(composite_eat->shm)) {
+		ret = PTR_ERR(composite_eat->shm);
+		goto err_put;
+	}
+
+	mutex_init(&composite_eat->lock);
+	spin_lock_init(&composite_eat->state_lock);
+	npcm_composite_eat_state_reset(&composite_eat->request_state);
+	init_completion(&composite_eat->complete);
+
+	composite_eat->cl.dev = dev;
+	composite_eat->cl.rx_callback = npcm_composite_eat_rx_callback;
+	composite_eat->cl.tx_block = true;
+	composite_eat->cl.tx_tout = 500;
+	composite_eat->chan = mbox_request_channel_byname(&composite_eat->cl,
+							  "composite-eat");
+	if (IS_ERR(composite_eat->chan)) {
+		ret = dev_err_probe(dev, PTR_ERR(composite_eat->chan),
+				    "failed to request mailbox channel\n");
+		goto err_put;
+	}
+
+	composite_eat->miscdev.minor = MISC_DYNAMIC_MINOR;
+	composite_eat->miscdev.name = NPCM_COMPOSITE_EAT_DEVICE_NAME;
+	composite_eat->miscdev.fops = &npcm_composite_eat_fops;
+	composite_eat->miscdev.parent = dev;
+	composite_eat->miscdev.mode = 0600;
+
+	ret = misc_register(&composite_eat->miscdev);
+	if (ret) {
+		mbox_free_channel(composite_eat->chan);
+		ret = dev_err_probe(dev, ret, "failed to register misc device\n");
+		goto err_put;
+	}
+
+	platform_set_drvdata(pdev, composite_eat);
+	dev_info(dev, "NPCM Composite EAT mailbox client initialized\n");
+	return 0;
+
+err_put:
+	kref_put(&composite_eat->refcount, npcm_composite_eat_release_ref);
+	return ret;
+}
+
+static void npcm_composite_eat_remove(struct platform_device *pdev)
+{
+	struct npcm_composite_eat *composite_eat = platform_get_drvdata(pdev);
+
+	mutex_lock(&composite_eat->lock);
+	composite_eat->removing = true;
+	mutex_unlock(&composite_eat->lock);
+	misc_deregister(&composite_eat->miscdev);
+	mbox_free_channel(composite_eat->chan);
+	platform_set_drvdata(pdev, NULL);
+	kref_put(&composite_eat->refcount, npcm_composite_eat_release_ref);
+}
+
+static const struct of_device_id npcm_composite_eat_match[] = {
+	{ .compatible = "nuvoton,npcm845-composite-eat" },
+	{ }
+};
+MODULE_DEVICE_TABLE(of, npcm_composite_eat_match);
+
+static struct platform_driver npcm_composite_eat_driver = {
+	.probe = npcm_composite_eat_probe,
+	.remove = npcm_composite_eat_remove,
+	.driver = {
+		.name = "npcm-composite-eat",
+		.of_match_table = npcm_composite_eat_match,
+	},
+};
+module_platform_driver(npcm_composite_eat_driver);
+
+MODULE_AUTHOR("Microsoft Corporation");
+MODULE_DESCRIPTION("NPCM Composite EAT mailbox client");
+MODULE_LICENSE("GPL");

--- a/include/uapi/linux/npcm-composite-eat.h
+++ b/include/uapi/linux/npcm-composite-eat.h
@@ -1,0 +1,57 @@
+/* SPDX-License-Identifier: GPL-2.0 WITH Linux-syscall-note */
+#ifndef _UAPI_LINUX_NPCM_COMPOSITE_EAT_H
+#define _UAPI_LINUX_NPCM_COMPOSITE_EAT_H
+
+#include <linux/ioctl.h>
+#include <linux/types.h>
+
+#define NPCM_COMPOSITE_EAT_ABI_VERSION 1
+#define NPCM_COMPOSITE_EAT_IOCTL_MAGIC 0xE6
+
+enum npcm_composite_eat_status {
+	NPCM_COMPOSITE_EAT_STATUS_OK = 0,
+	NPCM_COMPOSITE_EAT_STATUS_BAD_VERSION = 1,
+	NPCM_COMPOSITE_EAT_STATUS_BAD_REQUEST = 2,
+	NPCM_COMPOSITE_EAT_STATUS_TOO_MANY_RECORDS = 3,
+	NPCM_COMPOSITE_EAT_STATUS_REQUEST_TOO_LARGE = 4,
+	NPCM_COMPOSITE_EAT_STATUS_RESPONSE_TOO_SMALL = 5,
+	NPCM_COMPOSITE_EAT_STATUS_ADDRESS_INVALID = 6,
+	NPCM_COMPOSITE_EAT_STATUS_SIGN_FAILED = 7,
+	NPCM_COMPOSITE_EAT_STATUS_BUSY = 8,
+	NPCM_COMPOSITE_EAT_STATUS_INTERNAL = 9,
+	NPCM_COMPOSITE_EAT_STATUS_UNSUPPORTED = 10,
+};
+
+/**
+ * struct npcm_composite_eat_io - Generate a signed Composite EAT.
+ * @abi_version: Must be %NPCM_COMPOSITE_EAT_ABI_VERSION.
+ * @reserved: Must be zero.
+ * @req_ptr: Userspace pointer to the encoded request.
+ * @req_len: Request length in bytes.
+ * @reserved_req: Must be zero.
+ * @resp_ptr: Userspace pointer to the response buffer.
+ * @resp_cap: Response buffer capacity in bytes.
+ * @resp_len: Actual response length, or required length when @status is
+ *            %NPCM_COMPOSITE_EAT_STATUS_RESPONSE_TOO_SMALL.
+ * @status: Firmware status from &enum npcm_composite_eat_status. A valid
+ *          nonzero firmware status is returned with an ioctl return value of
+ *          zero so userspace can inspect @status and @resp_len.
+ * @reserved_resp: Must be zero.
+ */
+struct npcm_composite_eat_io {
+	__u32 abi_version;
+	__u32 reserved;
+	__aligned_u64 req_ptr;
+	__u32 req_len;
+	__u32 reserved_req;
+	__aligned_u64 resp_ptr;
+	__u32 resp_cap;
+	__u32 resp_len;
+	__u32 status;
+	__u32 reserved_resp;
+};
+
+#define NPCM_COMPOSITE_EAT_GENERATE \
+	_IOWR(NPCM_COMPOSITE_EAT_IOCTL_MAGIC, 1, struct npcm_composite_eat_io)
+
+#endif /* _UAPI_LINUX_NPCM_COMPOSITE_EAT_H */


### PR DESCRIPTION
Depends on #576 (`mailbox: synchronize NPCM channel shutdown`).

GitHub requires the base branch to exist in the upstream repository, while the
dependency branch currently exists only in the contributor fork. Therefore this
draft temporarily includes the #576 mailbox commit followed by the four
Composite EAT commits. After #576 merges, this branch will be rebased onto the
updated `NPCM-6.12-OpenBMC` target so the mailbox commit drops from the diff. The
four-commit client series will then be revalidated before leaving draft status.

## Summary

- add the NPCM845 Composite EAT DT binding and fixed ABI-v1 resource contract
- add a stable 48-byte 32/64-bit compatible ioctl UAPI and firmware status values
- add `/dev/npcm-composite-eat`, an ioctl-only mailbox client
- serialize requests and correlate request/response IDs
- quarantine shared memory after timeout or mailbox transmit timeout until the matching late response
- preserve required response length without truncating the signed token
- add hardware-independent KUnit coverage for ABI, resource geometry, response metadata, IDs, timeout, stale responses, and reset

## Feature gating

`CONFIG_NPCM_COMPOSITE_EAT` defaults to disabled. The generic client PR does not add or enable a board node. With the option disabled, the driver object and symbols are absent.

## ABI v1

- command `0x11`; mailbox channel 4 / notification `0x10`
- scratchpads 24-31 at `0xF0800E60..0xF0800E7F`
- shared memory `0x06201000`, size `0x5000`
- request region `0x1000`; response region `0x4000`
- one request in flight; 10-second timeout
- ioctl type `0xE6`, command 1; structure size 48 bytes

## Validation

- strict per-commit checkpatch: 0 errors, warnings, or checks
- `git diff --check`: pass
- Composite EAT KUnit under UML: 8/8 pass
- exported UAPI size/offset/ioctl assertions: pass for 32-bit and 64-bit
- focused DT schema, lint, and example compilation: pass
- ARM64 `W=1` affected-directory build: pass
- feature OFF: driver object and symbols absent
- feature ON: driver object and symbols present
- E2E hardware validation was done with a porting to MSFT OpenBMC, tested on DCSCM and compute platforms. 